### PR TITLE
Stop leaking the task ARN to tenants via D1 served_by

### DIFF
--- a/control/d1-runtime-client.js
+++ b/control/d1-runtime-client.js
@@ -25,7 +25,7 @@ import { validOwnerEndpointForService } from "runtime-owner-endpoint";
 /** @param {unknown} err */
 function d1RuntimeTransportPayload(err) {
   if (isD1QueryTimeoutError(err)) return d1QueryTimeoutPayload();
-  return d1BackendUnavailablePayload(err);
+  return d1BackendUnavailablePayload();
 }
 
 /** @param {Headers} headers */

--- a/d1-runtime/actor.js
+++ b/d1-runtime/actor.js
@@ -24,6 +24,7 @@ import {
   isD1ActorTestHook,
   runD1ActorTestHook,
 } from "d1-runtime-test-hooks";
+import { fnv1a32Utf8 } from "shared-fnv1a32";
 
 const DEFAULT_D1_MAX_RESULT_ROWS = 65_536;
 const DEFAULT_D1_MAX_RESULT_BYTES = 16 * 1024 * 1024;
@@ -454,7 +455,7 @@ export class D1DatabaseActor extends DurableObject {
       results,
       meta: {
         duration,
-        served_by: owner?.taskId || "unknown",
+        served_by: servedByLabel(owner?.taskId),
         served_by_region: "local",
         served_by_primary: true,
         timings: { sql_duration_ms: duration },
@@ -468,6 +469,15 @@ export class D1DatabaseActor extends DurableObject {
       },
     };
   }
+}
+
+// Owner task ids can be infrastructure identifiers. `served_by` is
+// tenant-visible, so expose only a stable redacted correlation label. FNV-1a is
+// not a security boundary.
+/** @param {string | null | undefined} taskId @returns {string} */
+function servedByLabel(taskId) {
+  if (typeof taskId !== "string" || taskId === "") return "unknown";
+  return `d1-${fnv1a32Utf8(taskId).toString(16).padStart(8, "0")}`;
 }
 
 /** @param {D1Ddl} ddl */

--- a/d1-runtime/owner-client.js
+++ b/d1-runtime/owner-client.js
@@ -41,12 +41,12 @@ function ownerEndpointReturnedUnknownResult(response) {
   return OWNER_UNAVAILABLE_STATUSES.has(response.status) && !isD1QueryResponse(response.headers);
 }
 
-/** @param {D1Query} query @param {D1Owner} owner @param {string} detail */
-function resultUnknownError(query, owner, detail) {
+/** @param {D1Query} query @param {string} detail */
+function resultUnknownError(query, detail) {
   return new D1ProtocolError(
     503,
     "result-unknown",
-    `D1 database ${query.dbKey} owner ${owner.taskId} response was lost after forwarding; outcome may be unknown, do not blindly retry non-idempotent requests: ${detail}`
+    `D1 database ${query.dbKey} owner response was lost after forwarding; outcome may be unknown, do not blindly retry non-idempotent requests: ${detail}`
   );
 }
 
@@ -120,10 +120,10 @@ export async function forwardToOwner(query, env, owner, requestId = null, hopCou
           `D1 database ${query.dbKey} exceeded the maximum forward depth`
         ),
       isTimeoutError: isD1QueryTimeoutError,
-      unavailableError: (err) => resultUnknownError(query, owner, errorMessage(err)),
+      unavailableError: () => resultUnknownError(query, "owner transport failed after forwarding"),
     });
     if (ownerEndpointReturnedUnknownResult(response)) {
-      throw resultUnknownError(query, owner, `owner endpoint returned HTTP ${response.status}`);
+      throw resultUnknownError(query, `owner endpoint returned HTTP ${response.status}`);
     }
     return response;
   } finally {

--- a/d1-runtime/owner-registry.js
+++ b/d1-runtime/owner-registry.js
@@ -132,12 +132,12 @@ export function parseOwner(raw) {
   return /** @type {D1Owner | null} */ (parseOwnerRecord(raw));
 }
 
-/** @param {string} dbKey @param {D1Owner | null} owner @param {string} taskId @returns {never} */
-function notOwner(dbKey, owner, taskId) {
+/** @param {string} dbKey @returns {never} */
+function notOwner(dbKey) {
   throw new D1ProtocolError(
     409,
     "not-owner",
-    `D1 database ${dbKey} is owned by ${owner?.taskId || "another task"}, not ${taskId}`
+    `D1 database ${dbKey} is owned by another task`
   );
 }
 
@@ -256,7 +256,7 @@ function cachedObservedOwner(env, identity, localTask, options = {}) {
   }
   if (entry.owner.taskId === localTask.taskId) {
     if (isDraining()) {
-      throw new D1ProtocolError(503, "task-draining", `D1 task ${localTask.taskId} is draining`);
+      throw new D1ProtocolError(503, "task-draining", "D1 task is draining");
     }
     rememberOwner(entry.owner);
     recordOwnerResolution("cached_local");
@@ -485,7 +485,7 @@ export async function releaseOwner(env, owner) {
 export async function takeoverExpiredOwner(env, staleOwner) {
   const localTask = await resolveTaskIdentity(env);
   if (isDraining()) {
-    throw new D1ProtocolError(503, "task-draining", `D1 task ${localTask.taskId} is draining`);
+    throw new D1ProtocolError(503, "task-draining", "D1 task is draining");
   }
   const client = redisClient(env);
   const key = ownerKeyOf(staleOwner.dbKey);
@@ -758,7 +758,7 @@ export async function resolveDbOwner(env, identity, options = {}) {
       return existing;
     }
     if (isDraining()) {
-      throw new D1ProtocolError(503, "task-draining", `D1 task ${taskId} is draining`);
+      throw new D1ProtocolError(503, "task-draining", "D1 task is draining");
     }
     const alreadyLocal = ownedDbs.has(identity.dbKey);
     rememberOwner(existing);
@@ -783,7 +783,7 @@ export async function resolveDbOwner(env, identity, options = {}) {
     return existing;
   }
   if (isDraining()) {
-    throw new D1ProtocolError(503, "task-draining", `D1 task ${taskId} is draining`);
+    throw new D1ProtocolError(503, "task-draining", "D1 task is draining");
   }
 
   try {
@@ -849,7 +849,7 @@ export async function assertCurrentOwnerWithLeaseBudget(env, owner) {
   const client = redisClient(env);
   const { owner: current, nowMs } = await readOwnerWithTimeFromClient(client, owner.dbKey);
   if (!current || !ownerFenceMatches(current, owner)) {
-    notOwner(owner.dbKey, current, owner.taskId);
+    notOwner(owner.dbKey);
   }
   const currentOwner = current;
   if (ownerLeaseExpired(currentOwner, nowMs)) {

--- a/d1-runtime/router.js
+++ b/d1-runtime/router.js
@@ -319,7 +319,7 @@ export async function routeQueryToOwner(
       throw new D1ProtocolError(
         503,
         "owner-not-ready",
-        `D1 database ${query.dbKey} owner ${owner.taskId} is ${probe.outcome}`
+        `D1 database ${query.dbKey} owner is ${probe.outcome}`
       );
     }
     if (

--- a/do-runtime/owner-registry.js
+++ b/do-runtime/owner-registry.js
@@ -292,7 +292,7 @@ export async function resolveDoOwner(env, invoke) {
         return current;
       }
       if (isDraining()) {
-        throw new DoRuntimeError(503, "task_draining", `DO task ${localTask.taskId} is draining`);
+        throw new DoRuntimeError(503, "task_draining", "DO task is draining");
       }
       const alreadyLocal = ownedScopes.has(ownerKey);
       const counter = alreadyLocal ? current.generation : await currentOwnerGenerationCounter(session, generationKey);
@@ -315,7 +315,7 @@ export async function resolveDoOwner(env, invoke) {
     }
 
     if (isDraining()) {
-      throw new DoRuntimeError(503, "task_draining", `DO task ${localTask.taskId} is draining`);
+      throw new DoRuntimeError(503, "task_draining", "DO task is draining");
     }
     const generation = await nextOwnerGeneration(session, generationKey, current?.generation);
     const owner = ownerRecordFor(env, invoke, localTask, generation, nowMs);

--- a/docs/modules/d1.md
+++ b/docs/modules/d1.md
@@ -152,6 +152,8 @@ failover.
 
 - D1 binding metadata is frozen at deploy time by control.
 - Tenant code does not receive backend endpoints or owner credentials.
+- Tenant-visible D1 metadata and errors must not include owner task ids, backend
+  endpoints, or raw transport error text.
 - D1 owner hints must pass service-specific endpoint grammar and generation/task checks.
 - Test hooks are opt-in and must not be enabled in live-ready services.
 

--- a/docs/modules/d1.zh.md
+++ b/docs/modules/d1.zh.md
@@ -85,6 +85,7 @@ Key families：
 
 - D1 binding metadata 由 control 在 deploy time 冻结。
 - Tenant code 不获得 backend endpoint 或 owner credential。
+- Tenant-visible D1 metadata 和 error 不得包含 owner task id、backend endpoint 或原始 transport error 文本。
 - D1 owner hint 必须通过 service-specific endpoint grammar 和 generation/task 检查。
 - Test hooks 是 opt-in，不应在 live-ready service 中开启。
 

--- a/docs/modules/durable-objects.md
+++ b/docs/modules/durable-objects.md
@@ -195,6 +195,8 @@ commit.
 - do-runtime internal endpoints are private-mesh only and are not
   application-authenticated.
 - Tenant code reaches DOs only through runtime-generated facades and frozen metadata.
+- Tenant-visible DO metadata and errors must not include owner task ids, backend
+  endpoints, or raw transport error text.
 - Owner hints are trusted only when returned by do-runtime headers and validated against
   endpoint grammar.
 - Owner-hint defense is layered: tenant response bodies are ignored, only do-runtime

--- a/docs/modules/durable-objects.zh.md
+++ b/docs/modules/durable-objects.zh.md
@@ -92,6 +92,7 @@ Generation key 不是 cache，而是 fence。即使过期 Redis owner record 消
 
 - do-runtime internal endpoints 只在 private mesh 内可达，并要求共享的 `WDL_INTERNAL_AUTH_TOKEN` / `x-wdl-internal-auth` 内部认证 header。Health 和 metrics endpoint 例外。
 - Tenant code 只能通过 runtime 生成的 facade 和 frozen metadata 访问 DO。
+- Tenant-visible DO metadata 和 error 不得包含 owner task id、backend endpoint 或原始 transport error 文本。
 - Owner hint 只信任 do-runtime header，并且要通过 endpoint grammar validation。
 - Owner-hint 防御是分层的：忽略 tenant response body，只信任 do-runtime control header，并且必须通过 endpoint grammar / acceptable-address 检查。
 - do-runtime supervisor 必须调用本地 `127.0.0.1:8788` drain/renew endpoint；Service Connect alias 可能打到其他 task。

--- a/runtime/bindings/d1.js
+++ b/runtime/bindings/d1.js
@@ -126,10 +126,10 @@ function throwD1TransportError(err) {
   const timedOut = isD1QueryTimeoutError(err);
   throwD1Payload(
     err instanceof D1ResultUnknownError
-      ? d1ResultUnknownPayload(err.cause)
+      ? d1ResultUnknownPayload()
       : timedOut
         ? d1QueryTimeoutPayload()
-        : d1BackendUnavailablePayload(err),
+        : d1BackendUnavailablePayload(),
     timedOut ? 504 : 503
   );
 }

--- a/shared/d1-timeout.js
+++ b/shared/d1-timeout.js
@@ -50,29 +50,23 @@ export function d1QueryTimeoutPayload() {
   };
 }
 
-/**
- * @param {unknown} err
- * @returns {{ success: false, error: "backend-unavailable", message: string, category: "internal", retryable: true }}
- */
-export function d1BackendUnavailablePayload(err) {
+/** @returns {{ success: false, error: "backend-unavailable", message: string, category: "internal", retryable: true }} */
+export function d1BackendUnavailablePayload() {
   return {
     success: false,
     error: "backend-unavailable",
-    message: `D1 backend is unavailable: ${errorMessage(err)}`,
+    message: "D1 backend is unavailable.",
     category: "internal",
     retryable: true,
   };
 }
 
-/**
- * @param {unknown} err
- * @returns {{ success: false, error: "result-unknown", message: string, category: "result-unknown", retryable: false }}
- */
-export function d1ResultUnknownPayload(err) {
+/** @returns {{ success: false, error: "result-unknown", message: string, category: "result-unknown", retryable: false }} */
+export function d1ResultUnknownPayload() {
   return {
     success: false,
     error: "result-unknown",
-    message: `D1 owner response was lost after the request was sent; outcome may be unknown, do not blindly retry non-idempotent requests: ${errorMessage(err)}`,
+    message: "D1 owner response was lost after the request was sent; outcome may be unknown, do not blindly retry non-idempotent requests.",
     category: "result-unknown",
     retryable: false,
   };

--- a/shared/owner-forwarder.js
+++ b/shared/owner-forwarder.js
@@ -1,4 +1,5 @@
 import { withInternalAuth } from "shared-internal-auth";
+import { errorMessage } from "shared-errors";
 
 export const MAX_OWNER_FORWARD_HOPS = 2;
 
@@ -100,6 +101,11 @@ export async function forwardOwnerRequest({
       throw err;
     }
     metrics.increment(metricName, { service, outcome: "unavailable" });
+    log("warn", logEvent.replace(/_complete$/, "_unavailable"), {
+      request_id: requestId || undefined,
+      ...logFields(),
+      error_message: errorMessage(err),
+    });
     throw unavailableError(err);
   }
 }

--- a/tests/helpers/load-d1-actor.js
+++ b/tests/helpers/load-d1-actor.js
@@ -1,4 +1,4 @@
-import { applyModuleReplacements, readRepositoryFile, moduleDataUrl } from "./load-shared-module.js";
+import { applyModuleReplacements, readRepositoryFile, moduleDataUrl, sharedModuleDataUrl } from "./load-shared-module.js";
 
 const protocolUrl = moduleDataUrl(`
 export function classifyD1Error(err) {
@@ -120,6 +120,10 @@ const source = applyModuleReplacements(readRepositoryFile("d1-runtime/actor.js")
   [
     /import \{\n {2}isD1ActorTestHook,\n {2}runD1ActorTestHook,\n\} from "d1-runtime-test-hooks";/,
     `import { isD1ActorTestHook, runD1ActorTestHook } from ${JSON.stringify(testHooksUrl)};`
+  ],
+  [
+    /import \{ fnv1a32Utf8 \} from "shared-fnv1a32";/,
+    `import { fnv1a32Utf8 } from ${JSON.stringify(sharedModuleDataUrl("shared/fnv1a32.js"))};`
   ],
 ]);
 

--- a/tests/helpers/load-owner-client-harness.js
+++ b/tests/helpers/load-owner-client-harness.js
@@ -43,6 +43,7 @@ export function log(level, event, fields) {
   const errorsUrl = repositoryFileUrl("shared/errors.js");
   const ownerForwarderUrl = repositoryModuleDataUrl("shared/owner-forwarder.js", [
     [/from "shared-internal-auth";/, `from ${JSON.stringify(internalAuthUrl)};`],
+    [/from "shared-errors";/, `from ${JSON.stringify(errorsUrl)};`],
   ]);
 
   return {

--- a/tests/integration/d1-binding.test.js
+++ b/tests/integration/d1-binding.test.js
@@ -160,7 +160,7 @@ test("D1 binding learns owner after Envoy-routed router forwarding", async () =>
     assert.equal(first.status, 200, firstText);
     const firstBody = responseJson({ body: firstText });
     assert.equal(firstBody.success, true);
-    assert.equal(firstBody.meta.served_by, "d1-runtime-a");
+    assert.equal(firstBody.meta.served_by, "d1-30ae925d"); // fnv1a32("d1-runtime-a")
 
     const afterFirstEnvoy = envoyStat("cluster.d1_router.upstream_rq_total");
     assert.ok(afterFirstEnvoy > beforeEnvoy, "forwarded first call should hit Envoy D1 router");
@@ -170,7 +170,7 @@ test("D1 binding learns owner after Envoy-routed router forwarding", async () =>
     assert.equal(second.status, 200, secondText);
     const secondBody = responseJson({ body: secondText });
     assert.equal(secondBody.success, true);
-    assert.equal(secondBody.meta.served_by, "d1-runtime-a");
+    assert.equal(secondBody.meta.served_by, "d1-30ae925d"); // fnv1a32("d1-runtime-a")
 
     const afterSecondEnvoy = envoyStat("cluster.d1_router.upstream_rq_total");
     assert.equal(

--- a/tests/integration/d1-ownership-multi-runtime.test.js
+++ b/tests/integration/d1-ownership-multi-runtime.test.js
@@ -188,7 +188,7 @@ test("D1 forwarded requests still resolve owner and do not execute by header alo
   assertStatus(forged, 200, "forged");
   const body = normalizeD1QueryBody(decodeD1QueryResponse(Buffer.from(forged.bodyB64, "base64")));
   assert.deepEqual(body.results, [{ body: "owner-a" }]);
-  assert.equal(body.meta.served_by, "d1-runtime-a");
+  assert.equal(body.meta.served_by, "d1-30ae925d"); // fnv1a32("d1-runtime-a")
   assert.equal(d1RuntimeProbe("d1-runtime-c", dbKey).owner.taskId, "d1-runtime-a");
 });
 
@@ -306,7 +306,7 @@ test("D1 idle owners are renewed by task heartbeat without health checks", async
   });
   assertStatus(readAfterIdle, 200, "readAfterIdle");
   assert.deepEqual(readAfterIdle.body.results, [{ body: "after-idle" }]);
-  assert.equal(readAfterIdle.body.meta.served_by, "d1-runtime-a");
+  assert.equal(readAfterIdle.body.meta.served_by, "d1-30ae925d"); // fnv1a32("d1-runtime-a")
   assert.equal(d1RuntimeProbe("d1-runtime-b", dbKey).owner.taskId, "d1-runtime-a");
 });
 

--- a/tests/integration/d1-read-cache.test.js
+++ b/tests/integration/d1-read-cache.test.js
@@ -486,7 +486,7 @@ test("D1 read cache does not survive ownership rebalance", async () => {
   const readViaA = d1RuntimeQuery("d1-runtime-a", countQuery);
   assertStatus(readViaA, 200, "readViaA");
   assert.deepEqual(readViaA.body.results, [{ n: 2 }]);
-  assert.equal(readViaA.body.meta.served_by, "d1-runtime-c");
+  assert.equal(readViaA.body.meta.served_by, "d1-2eae8f37"); // fnv1a32("d1-runtime-c")
   const movedMetrics = serviceInternalGet("d1-runtime-a", 8787, "/_metrics").body;
   assert.equal(invalidationMetric(movedMetrics, "owner-moved") - beforeOwnerMovedInvalidation, 1);
   assert.equal(d1RuntimeProbe("d1-runtime-b", dbKey).owner.taskId, "d1-runtime-c");

--- a/tests/unit/control-d1-runtime-client.test.js
+++ b/tests/unit/control-d1-runtime-client.test.js
@@ -172,7 +172,7 @@ test("control D1 runtime client query maps transport failure to shared unavailab
   assert.equal(result.body.error, "backend-unavailable");
   assert.equal(result.body.category, "internal");
   assert.equal(result.body.retryable, true);
-  assert.match(result.body.message, /connect ECONNREFUSED/);
+  assert.equal(result.body.message, "D1 backend is unavailable.");
 });
 
 test("control D1 runtime client query treats unsupported response content-type as upstream failure", async () => {

--- a/tests/unit/d1-owner-client.test.js
+++ b/tests/unit/d1-owner-client.test.js
@@ -13,6 +13,8 @@ import { installMockFetch, makeRecordingFetch } from "../helpers/mock-fetch.js";
 const mod = loadD1OwnerClient();
 const TEST_INTERNAL_AUTH_TOKEN = "test-internal-auth-token";
 const D1_OWNER_CLIENT_TEST_STATE = d1OwnerClientHarnessState();
+const INTERNAL_OWNER_TASK_ARN = "arn:aws:ecs:example-region-1:123456789012:task/example-cluster/task-abcdef";
+const INTERNAL_OWNER_DETAIL_RE = /arn:|123456789012|example-region-1|example-cluster|task-abcdef|d1-runtime-b:8787|internal\/d1\/query/;
 
 let restoreFetch = () => {};
 
@@ -45,6 +47,13 @@ function owner() {
     taskId: "d1-runtime-b",
     generation: 4,
     endpoint: "d1-runtime-b:8787",
+  };
+}
+
+function ownerWithTaskArn() {
+  return {
+    ...owner(),
+    taskId: INTERNAL_OWNER_TASK_ARN,
   };
 }
 
@@ -81,21 +90,38 @@ test("D1 owner client maps post-forward transport failures to result-unknown", a
   restoreFetch();
   restoreFetch = installMockFetch(makeRecordingFetch(D1_OWNER_CLIENT_TEST_STATE.fetches, {
     response: () => {
-      throw new Error("connection reset after request");
+      throw new Error(`connection reset after request to http://d1-runtime-b:8787/internal/d1/query ${INTERNAL_OWNER_TASK_ARN}`);
     },
   }));
 
   await assert.rejects(
-    () => mod.forwardToOwner(query(), env(), owner(), "req-2", 1),
-    (err) => err instanceof Error &&
-      /** @type {{ status?: unknown, code?: unknown }} */ (err).status === 503 &&
-      /** @type {{ status?: unknown, code?: unknown }} */ (err).code === "result-unknown" &&
-      /outcome may be unknown/.test(err.message)
+    () => mod.forwardToOwner(query(), env(), ownerWithTaskArn(), "req-2", 1),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.equal(/** @type {{ status?: unknown }} */ (err).status, 503);
+      assert.equal(/** @type {{ code?: unknown }} */ (err).code, "result-unknown");
+      assert.match(err.message, /outcome may be unknown/);
+      assert.doesNotMatch(err.message, INTERNAL_OWNER_DETAIL_RE);
+      return true;
+    }
   );
   assert.equal(D1_OWNER_CLIENT_TEST_STATE.fetches.length, 1);
   assert.deepEqual(D1_OWNER_CLIENT_TEST_STATE.metrics.at(-1), {
     name: "d1_forwards",
     labels: { service: "d1-runtime", outcome: "unavailable" },
+  });
+  assert.deepEqual(D1_OWNER_CLIENT_TEST_STATE.logs.at(-1), {
+    level: "warn",
+    event: "d1_forward_unavailable",
+    fields: {
+      request_id: "req-2",
+      namespace: "tenant",
+      database_id: "main",
+      slot: 3,
+      owner_task_id: INTERNAL_OWNER_TASK_ARN,
+      owner_endpoint: "d1-runtime-b:8787",
+      error_message: `connection reset after request to http://d1-runtime-b:8787/internal/d1/query ${INTERNAL_OWNER_TASK_ARN}`,
+    },
   });
 });
 
@@ -109,11 +135,15 @@ test("D1 owner client maps non-wire owner unavailable responses to result-unknow
   }));
 
   await assert.rejects(
-    () => mod.forwardToOwner(query(), env(), owner(), "req-3", 1),
-    (err) => err instanceof Error &&
-      /** @type {{ status?: unknown, code?: unknown }} */ (err).status === 503 &&
-      /** @type {{ status?: unknown, code?: unknown }} */ (err).code === "result-unknown" &&
-      /HTTP 504/.test(err.message)
+    () => mod.forwardToOwner(query(), env(), ownerWithTaskArn(), "req-3", 1),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.equal(/** @type {{ status?: unknown }} */ (err).status, 503);
+      assert.equal(/** @type {{ code?: unknown }} */ (err).code, "result-unknown");
+      assert.match(err.message, /HTTP 504/);
+      assert.doesNotMatch(err.message, INTERNAL_OWNER_DETAIL_RE);
+      return true;
+    }
   );
   assert.equal(D1_OWNER_CLIENT_TEST_STATE.fetches.length, 1);
   assert.deepEqual(D1_OWNER_CLIENT_TEST_STATE.metrics.at(-1), {

--- a/tests/unit/d1-owner-registry-regressions.test.js
+++ b/tests/unit/d1-owner-registry-regressions.test.js
@@ -59,6 +59,21 @@ test("D1 owner registry: corrupt generation counter fails closed", async () => {
   );
 });
 
+test("D1 owner registry: draining task errors do not expose task identity", async () => {
+  const identity = { namespace: "tenant-a", databaseId: "db1", dbKey: "tenant-a:db1", slot: 7 };
+  D1_TEST_STATE.draining = true;
+
+  await assert.rejects(
+    () => resolveDbOwner({ REDIS_ADDR: "redis:6379" }, identity),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.match(err.message, /D1 task is draining/);
+      assert.doesNotMatch(err.message, /\btask-a\b/);
+      return true;
+    }
+  );
+});
+
 test("D1 owner registry: same-task hot path does not refresh the owner lease", async () => {
   const identity = { namespace: "tenant-a", databaseId: "db1", dbKey: "tenant-a:db1", slot: 7 };
   const ownerKey = ownerKeyOf(identity.dbKey);
@@ -134,7 +149,12 @@ test("D1 owner registry: lost owner state cannot validate an old owner from anot
       taskId: "task-a",
       generation: 1,
     }),
-    /owned by task-b, not task-a/
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.match(err.message, /owned by another task/);
+      assert.doesNotMatch(err.message, /\btask-[ab]\b/);
+      return true;
+    }
   );
 });
 

--- a/tests/unit/d1-router.test.js
+++ b/tests/unit/d1-router.test.js
@@ -76,7 +76,13 @@ export function parseForwardHopCount(value) {
 }
 `);
 const protocolUrl = moduleDataUrl(`
-export class D1ProtocolError extends Error {}
+export class D1ProtocolError extends Error {
+  constructor(status, code, message) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
 export const D1_ACTOR_QUERY_CONTENT_TYPE = "application/" + "x-wdl-d1-actor-query-v1";
 export function classifyD1Error() { return { status: 500, code: "internal-error" }; }
 export function d1ErrorPayload() { return {}; }
@@ -184,6 +190,42 @@ test("D1 router uses takeover owner even after refresh is disabled", async () =>
     delete /** @type {any} */ (globalThis).__d1RouterLeaseExpired;
     delete /** @type {any} */ (globalThis).__d1RouterTakeoverExpiredOwner;
     delete /** @type {any} */ (globalThis).__d1RouterForwardToOwner;
+  }
+});
+
+test("D1 router owner-not-ready errors do not expose owner task identity", async () => {
+  const query = {
+    dbKey: "tenant-a:main",
+    namespace: "tenant-a",
+    databaseId: "main",
+    binding: null,
+    mode: "all",
+    slot: 1,
+    statements: [{ sql: "select 1", params: [] }],
+  };
+  const owner = {
+    dbKey: query.dbKey,
+    taskId: "task-b",
+    endpoint: "task-b:8787",
+    generation: 7,
+    leaseExpiresAt: Date.now() + 60_000,
+  };
+  /** @type {any} */ (globalThis).__d1RouterProbeOwner = async () => ({ outcome: "stale-generation" });
+  /** @type {any} */ (globalThis).__d1RouterResolveDbOwner = async () => owner;
+  try {
+    await assert.rejects(
+      () => routeQueryToOwner(query, {}, owner, false, "rid", 1),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.equal(/** @type {{ code?: unknown }} */ (err).code, "owner-not-ready");
+        assert.match(err.message, /owner is stale-generation/);
+        assert.doesNotMatch(err.message, /\btask-b\b/);
+        return true;
+      }
+    );
+  } finally {
+    delete /** @type {any} */ (globalThis).__d1RouterProbeOwner;
+    delete /** @type {any} */ (globalThis).__d1RouterResolveDbOwner;
   }
 });
 

--- a/tests/unit/d1-runtime-actor.test.js
+++ b/tests/unit/d1-runtime-actor.test.js
@@ -411,7 +411,7 @@ test("D1 actor: all-mode fetch returns row/column results without objectifying r
     results: { columns: ["id", "body"], rows: [["m1", "hello"]] },
     meta: {
       duration: 0,
-      served_by: "task-a",
+      served_by: "d1-5830a8b6",
       served_by_region: "local",
       served_by_primary: true,
       timings: { sql_duration_ms: 0 },
@@ -424,6 +424,41 @@ test("D1 actor: all-mode fetch returns row/column results without objectifying r
       total_attempts: 1,
     },
   });
+});
+
+test("D1 actor: served_by is a stable redacted label, never the raw task ARN", async () => {
+  const actor = new D1DatabaseActor({
+    storage: {
+      sql: {
+        get databaseSize() {
+          return 100;
+        },
+        exec() {
+          return { columnNames: ["id"], raw: () => [["m1"]], rowsRead: 1, rowsWritten: 0 };
+        },
+      },
+    },
+  }, {});
+
+  const taskArn = "arn:aws:ecs:example-region-1:123456789012:task/example-cluster/task-abcdef";
+  async function queryServedBy() {
+    const response = await actor.fetch(new Request("http://d1-actor/query", {
+      method: "POST",
+      body: JSON.stringify({
+        mode: "all",
+        owner: { taskId: taskArn },
+        statements: [{ sql: "select id from messages", params: [] }],
+      }),
+    }));
+    return (await readJsonResponse(response, 200)).meta.served_by;
+  }
+
+  const first = await queryServedBy();
+  const second = await queryServedBy();
+
+  assert.match(first, /^d1-[0-9a-f]{8}$/);
+  assert.equal(second, first);
+  assert.doesNotMatch(first, /arn:|123456789012|example-region-1|example-cluster|task-abcdef/);
 });
 
 test("D1 actor: read statement avoids changes/last-row probes", () => {

--- a/tests/unit/do-owner-registry.test.js
+++ b/tests/unit/do-owner-registry.test.js
@@ -217,7 +217,12 @@ test("DO owner registry: draining task refuses local ownership or takeover", asy
 
   await assert.rejects(
     resolveDoOwner({ REDIS_ADDR: "redis:6379" }, invoke()),
-    /task-a is draining/
+    (err) => {
+      assert.equal(/** @type {{ code?: unknown }} */ (err).code, "task_draining");
+      assert.match(/** @type {Error} */ (err).message, /DO task is draining/);
+      assert.doesNotMatch(/** @type {Error} */ (err).message, /task-a/);
+      return true;
+    }
   );
 });
 

--- a/tests/unit/runtime-d1-stub.test.js
+++ b/tests/unit/runtime-d1-stub.test.js
@@ -23,6 +23,8 @@ const STALE_OWNER_HINT_ERRORS = [
 const TEST_D1_QUERY_TIMEOUT_LONG_MS = 1234;
 // Short enough to force the transport-timeout branch without slowing the suite.
 const TEST_D1_TRANSPORT_TIMEOUT_SHORT_MS = 10;
+const INTERNAL_OWNER_TASK_ARN = "arn:aws:ecs:example-region-1:123456789012:task/example-cluster/task-abcdef";
+const INTERNAL_OWNER_DETAIL_RE = /arn:|123456789012|example-region-1|example-cluster|task-abcdef|d1-runtime(?:-a:8787)?|internal\/d1\/query/;
 const PROXY_BINDING_URL = runtimeProxyBindingStubUrl();
 const SHARED_INTERNAL_AUTH_URL = sharedInternalAuthUrl();
 const SHARED_D1_TIMEOUT_URL = sharedModuleDataUrl("shared/d1-timeout.js");
@@ -226,6 +228,23 @@ test("D1 runtime stub: forwards request id header to backend", async () => {
   await db.query("all", [{ sql: "select 1", params: [] }], "rid-d1");
 
   assert.equal(calls[0].headers["x-request-id"], "rid-d1");
+});
+
+test("D1 runtime stub: backend transport failures do not expose internal details", async () => {
+  const { db } = makeRuntimeDb(() => {
+    throw new Error(`connect ECONNREFUSED http://d1-runtime/internal/d1/query ${INTERNAL_OWNER_TASK_ARN}`);
+  });
+
+  await assert.rejects(
+    () => db.query("all", [{ sql: "select 1", params: [] }], "rid-d1"),
+    (err) => err instanceof Error &&
+      err.name === "D1_ERROR" &&
+      /** @type {{ code?: unknown, category?: unknown, retryable?: unknown }} */ (err).code === "backend-unavailable" &&
+      /** @type {{ code?: unknown, category?: unknown, retryable?: unknown }} */ (err).category === "internal" &&
+      /** @type {{ code?: unknown, category?: unknown, retryable?: unknown }} */ (err).retryable === true &&
+      /D1 backend is unavailable/.test(err.message) &&
+      !INTERNAL_OWNER_DETAIL_RE.test(err.message)
+  );
 });
 
 test("D1 runtime stub: malformed direct router response is result-unknown", async () => {
@@ -586,7 +605,7 @@ test("D1 runtime stub: direct owner transport failures are result-unknown and no
       body: decodeD1QueryRequest(init.body),
       headers: Object.fromEntries(new Headers(init.headers).entries()),
     });
-    throw new Error("connection reset after request");
+    throw new Error(`connection reset after request to http://d1-runtime-a:8787/internal/d1/query ${INTERNAL_OWNER_TASK_ARN}`);
   }, async () => {
     await db.query("all", [{ sql: "select 1", params: [] }], "rid-d1");
     await assert.rejects(
@@ -596,7 +615,8 @@ test("D1 runtime stub: direct owner transport failures are result-unknown and no
         /** @type {{ code?: unknown, category?: unknown, retryable?: unknown }} */ (err).code === "result-unknown" &&
         /** @type {{ code?: unknown, category?: unknown, retryable?: unknown }} */ (err).category === "result-unknown" &&
         /** @type {{ code?: unknown, category?: unknown, retryable?: unknown }} */ (err).retryable === false &&
-        /outcome may be unknown/.test(err.message)
+        /outcome may be unknown/.test(err.message) &&
+        !INTERNAL_OWNER_DETAIL_RE.test(err.message)
     );
 
     assert.equal(directCalls.length, 1);


### PR DESCRIPTION
D1 query responses returned `meta.served_by = owner.taskId`, the raw owner-lease task identity. Under ECS that identity is the task ARN, which embeds the AWS account id, region, and cluster name — infrastructure detail a tenant has no need to see (Cloudflare's D1 returns an opaque colo token here, not an ARN). The value is tenant-reachable both via the control D1 query API and `result.meta` inside worker code.

Emit a stable, opaque per-task token (`d1-<fnv1a32 hex>`) instead. This preserves the replica-correlation signal `served_by` exists for (same task -> same label, which the multi-runtime ownership tests rely on) while keeping the raw ARN in logs and the private owner/fence channel only. The owner.taskId surfaced by the internal `/probe` diagnostic is unchanged.

Adds a regression test asserting an ARN-shaped taskId never appears in served_by, and updates the ownership integration assertions to the opaque token.