### PR TITLE
Remove unused and redundant platform code

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -7,7 +7,6 @@ import {
   AuthPolicyError,
   BOOTSTRAP_TOKEN_ID,
   assertTenantNs,
-  createDelegatedIssueTemplateMap,
   evaluateAccess,
   generatePlaintextToken,
   generateTokenId,
@@ -395,9 +394,8 @@ export default class Auth extends WorkerEntrypoint {
       ({ kind, ns } = validateIssueInput({ kind: input?.kind, ns: input?.ns }));
       if (kind === "token-issuer") {
         issueTemplates = validateIssueTemplatesInput(input?.issueTemplates);
-        const configured = createDelegatedIssueTemplateMap();
         for (const templateId of issueTemplates) {
-          resolveDelegatedIssueTemplate(templateId, configured);
+          resolveDelegatedIssueTemplate(templateId);
         }
       } else if (input?.issueTemplates !== undefined) {
         throw new AuthPolicyError(400, "invalid_template_request",

--- a/auth/lib.js
+++ b/auth/lib.js
@@ -123,9 +123,6 @@ const STRICT_ISO_UTC_RE =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,3})?Z$/;
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
 const ISSUE_TEMPLATE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
-const ISSUE_TEMPLATE_VERSION_RE = /^[A-Za-z0-9._:-]{1,64}$/;
-export const MAX_DELEGATED_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
-export const MAX_DELEGATED_TOKEN_ACTIVE_QUOTA = 10_000;
 
 /**
  * @typedef {{
@@ -136,7 +133,6 @@ export const MAX_DELEGATED_TOKEN_ACTIVE_QUOTA = 10_000;
  *   ttlSeconds: number,
  *   activeQuota: number,
  *   version: string,
- *   disabled: boolean,
  * }} DelegatedIssueTemplate
  */
 
@@ -152,7 +148,6 @@ export const DELEGATED_ISSUE_TEMPLATES = Object.freeze([
     ttlSeconds: 6 * 60 * 60,
     activeQuota: 100,
     version: "1",
-    disabled: false,
   }),
   Object.freeze({
     id: "wdl-cli-integration",
@@ -165,9 +160,13 @@ export const DELEGATED_ISSUE_TEMPLATES = Object.freeze([
     ttlSeconds: 60 * 60,
     activeQuota: 50,
     version: "1",
-    disabled: false,
   }),
 ]);
+
+/** @type {Map<string, DelegatedIssueTemplate>} */
+const delegatedIssueTemplatesById = new Map(
+  DELEGATED_ISSUE_TEMPLATES.map((template) => [template.id, template]),
+);
 
 const STORED_TIMESTAMP_FIELDS = Object.freeze([
   "created_at",
@@ -229,11 +228,6 @@ export function validateExpiresAt(value, now = Date.now()) {
     throw new AuthPolicyError(400, "expired_at_in_past", "expiresAt must be in the future");
   }
   return d.toISOString();
-}
-
-/** @param {unknown} value */
-function isPlainObject(value) {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 /** @param {unknown} id */
@@ -298,126 +292,12 @@ export function parseStoredIssueTemplates(stored) {
   }
 }
 
-/**
- * @param {unknown} templates
- * @returns {Map<string, DelegatedIssueTemplate>}
- */
-export function createDelegatedIssueTemplateMap(templates = DELEGATED_ISSUE_TEMPLATES) {
-  if (!Array.isArray(templates) || templates.length === 0) {
-    throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-      "delegated issue templates must be a non-empty array");
-  }
-  /** @type {Map<string, DelegatedIssueTemplate>} */
-  const out = new Map();
-  for (const item of templates) {
-    if (!isPlainObject(item)) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        "delegated issue templates must be objects");
-    }
-    const template = /** @type {Record<string, unknown>} */ (item);
-    if (!isIssueTemplateId(template.id)) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        "delegated issue template id is invalid");
-    }
-    const id = /** @type {string} */ (template.id);
-    if (out.has(id)) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        `duplicate delegated issue template "${id}"`);
-    }
-    if (typeof template.targetKind !== "string" ||
-        !Object.hasOwn(ROLES, template.targetKind) ||
-        template.targetKind === "ops" ||
-        template.targetKind === "ops-observer" ||
-        template.targetKind === "token-issuer" ||
-        ROLES[template.targetKind].boundNsKind !== "tenant") {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        `template "${id}" has invalid targetKind`);
-    }
-    if (!isPlainObject(template.nsGenerator)) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        `template "${id}" must define nsGenerator`);
-    }
-    const generator = /** @type {Record<string, unknown>} */ (template.nsGenerator);
-    if (typeof generator.prefix !== "string" || !generator.prefix) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        `template "${id}" nsGenerator.prefix must be non-empty`);
-    }
-    const randomHexBytes = generator.randomHexBytes;
-    if (typeof randomHexBytes !== "number" ||
-        !Number.isInteger(randomHexBytes) ||
-        randomHexBytes < 1 ||
-        randomHexBytes > 16) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        `template "${id}" nsGenerator.randomHexBytes must be 1..16`);
-    }
-    const sampleNs = generator.prefix + "0".repeat(randomHexBytes * 2);
-    if (!isValidTenantNs(sampleNs)) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        `template "${id}" generated namespace shape is invalid`);
-    }
-    if (typeof template.labelTemplate !== "string" ||
-        !template.labelTemplate ||
-        template.labelTemplate.length > 128 ||
-        !template.labelTemplate.includes("{ns}")) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        `template "${id}" labelTemplate must include {ns}`);
-    }
-    const maxLabel = template.labelTemplate.replaceAll("{ns}", sampleNs);
-    if (maxLabel.length > 128) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        `template "${id}" labelTemplate renders over 128 chars`);
-    }
-    const ttlSeconds = template.ttlSeconds;
-    if (typeof ttlSeconds !== "number" ||
-        !Number.isInteger(ttlSeconds) ||
-        ttlSeconds < 1 ||
-        ttlSeconds > MAX_DELEGATED_TOKEN_TTL_SECONDS) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        `template "${id}" ttlSeconds is outside the server limit`);
-    }
-    const activeQuota = template.activeQuota;
-    if (typeof activeQuota !== "number" ||
-        !Number.isInteger(activeQuota) ||
-        activeQuota < 1 ||
-        activeQuota > MAX_DELEGATED_TOKEN_ACTIVE_QUOTA) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        `template "${id}" activeQuota is outside the server limit`);
-    }
-    const version = template.version === undefined ? "1" : template.version;
-    if (typeof version !== "string" || !ISSUE_TEMPLATE_VERSION_RE.test(version)) {
-      throw new AuthPolicyError(503, "delegated_issue_misconfigured",
-        `template "${id}" version is invalid`);
-    }
-    out.set(id, {
-      id,
-      targetKind: template.targetKind,
-      nsGenerator: {
-        prefix: generator.prefix,
-        randomHexBytes,
-      },
-      labelTemplate: template.labelTemplate,
-      ttlSeconds,
-      activeQuota,
-      version,
-      disabled: template.disabled === true,
-    });
-  }
-  return out;
-}
-
-/**
- * @param {string} templateId
- * @param {Map<string, DelegatedIssueTemplate>} [configured]
- */
-export function resolveDelegatedIssueTemplate(templateId, configured = createDelegatedIssueTemplateMap()) {
-  const template = configured.get(templateId);
+/** @param {string} templateId */
+export function resolveDelegatedIssueTemplate(templateId) {
+  const template = delegatedIssueTemplatesById.get(templateId);
   if (!template) {
     throw new AuthPolicyError(400, "invalid_template",
       `template "${templateId}" does not exist`);
-  }
-  if (template.disabled) {
-    throw new AuthPolicyError(400, "template_disabled",
-      `template "${templateId}" is disabled`);
   }
   return template;
 }

--- a/control/handlers/reload.js
+++ b/control/handlers/reload.js
@@ -1,50 +1,32 @@
 import { jsonResponse, publishReload } from "control-shared";
 
-/** @param {unknown} result */
-function publishResultForResponse(result) {
-  const record = result && typeof result === "object"
-    ? /** @type {Record<string, unknown>} */ (result)
-    : {};
-  /** @type {{ ok: boolean, channel: string | null, durationMs: number, receivers?: number, error?: string }} */
-  const out = {
-    ok: Boolean(record.ok),
-    channel: typeof record.channel === "string" ? record.channel : null,
-    durationMs: Number.isFinite(record.duration_ms) ? Number(record.duration_ms) : 0,
-  };
-  if (typeof record.receivers === "number") out.receivers = record.receivers;
-  if (typeof record.error === "string") out.error = record.error;
-  return out;
+/**
+ * @typedef {{ ok: boolean, channel: string, duration_ms: number, receivers?: number, error?: string }} PublishResult
+ * @typedef {{ ok: boolean, duration_ms: number, declaredHosts?: number, declarationKeysRemoved?: number, error?: string }} RepairResult
+ */
+
+/** @param {PublishResult} result */
+function publishResultForResponse({ duration_ms: durationMs, ...result }) {
+  return { ...result, durationMs: durationMs };
 }
 
-/** @param {unknown} result */
+/** @param {RepairResult} result */
+function repairResultForResponse({ duration_ms: durationMs, ...result }) {
+  return { ...result, durationMs: durationMs };
+}
+
+/** @param {Awaited<ReturnType<typeof publishReload>>} result */
 function reloadResultForResponse(result) {
-  const record = result && typeof result === "object"
-    ? /** @type {Record<string, unknown>} */ (result)
-    : {};
+  const base = {
+    ok: result.ok,
+    declarations: repairResultForResponse(result.declarations),
+  };
+  if (result.routes === undefined || result.patterns === undefined) return base;
   return {
-    ok: Boolean(record.ok),
-    declarations: repairResultForResponse(record.declarations),
-    routes: publishResultForResponse(record.routes),
-    patterns: publishResultForResponse(record.patterns),
+    ...base,
+    routes: publishResultForResponse(result.routes),
+    patterns: publishResultForResponse(result.patterns),
   };
-}
-
-/** @param {unknown} result */
-function repairResultForResponse(result) {
-  const record = result && typeof result === "object"
-    ? /** @type {Record<string, unknown>} */ (result)
-    : {};
-  /** @type {{ ok: boolean, durationMs: number, declaredHosts?: number, declarationKeysRemoved?: number, error?: string }} */
-  const out = {
-    ok: Boolean(record.ok),
-    durationMs: Number.isFinite(record.duration_ms) ? Number(record.duration_ms) : 0,
-  };
-  if (typeof record.declaredHosts === "number") out.declaredHosts = record.declaredHosts;
-  if (typeof record.declarationKeysRemoved === "number") {
-    out.declarationKeysRemoved = record.declarationKeysRemoved;
-  }
-  if (typeof record.error === "string") out.error = record.error;
-  return out;
 }
 
 /** @param {{ requestId: string }} args */

--- a/control/json-body.js
+++ b/control/json-body.js
@@ -5,25 +5,21 @@ export const DEFAULT_JSON_BODY_MAX_BYTES = 1024 * 1024;
 
 /**
  * @param {Request} request
- * @param {{ requireObject?: boolean, allowEmpty?: boolean, maxBytes?: number }} [opts]
+ * @param {{ requireObject?: boolean, maxBytes?: number }} [opts]
  */
 export async function readJsonBody(
   request,
-  { requireObject = false, allowEmpty = false, maxBytes = DEFAULT_JSON_BODY_MAX_BYTES } = {},
+  { requireObject = false, maxBytes = DEFAULT_JSON_BODY_MAX_BYTES } = {},
 ) {
   let body;
   try {
     const text = await readBoundedText(request, maxBytes);
     if (text === "") {
-      if (!allowEmpty) {
-        return {
-          response: jsonError(400, "invalid_json", "Body must be valid JSON"),
-        };
-      }
-      body = {};
-    } else {
-      body = JSON.parse(text);
+      return {
+        response: jsonError(400, "invalid_json", "Body must be valid JSON"),
+      };
     }
+    body = JSON.parse(text);
   } catch (err) {
     if (err instanceof BodyTooLargeError) {
       return {

--- a/d1-runtime/router.js
+++ b/d1-runtime/router.js
@@ -197,11 +197,14 @@ function recordQueryComplete({ requestId, query, startedAt, status, code, outcom
  * @param {Request} request
  * @param {D1Env} env
  * @param {string | null} [requestId]
- * @param {{ normalize?: (body: unknown) => D1Query, read?: (request: Request) => Promise<unknown> } | ((body: unknown) => D1Query)} [options]
+ * @param {{ normalize?: (body: unknown) => D1Query, read?: (request: Request) => Promise<unknown> }} [options]
  */
-export async function handleQuery(request, env, requestId = null, options = {}) {
-  const normalize = typeof options === "function" ? options : options.normalize || normalizeQueryRequest;
-  const read = typeof options === "function" ? readD1QueryRequest : options.read || readD1QueryRequest;
+export async function handleQuery(
+  request,
+  env,
+  requestId = null,
+  { normalize = normalizeQueryRequest, read = readD1QueryRequest } = {},
+) {
   const startedAt = Date.now();
   requestId = requestId || ensureRequestId(request.headers);
   // Forwarding is not an authorization signal. It only suppresses duplicate

--- a/do-runtime/protocol.js
+++ b/do-runtime/protocol.js
@@ -675,43 +675,21 @@ export async function readLocalActorInvokeRequest(request) {
   if (request.headers.get(LOCAL_ACTOR_ENVELOPE_HEADER) !== LOCAL_ACTOR_ENVELOPE_MARKER) {
     throw new DoRuntimeError(415, "unsupported_media_type", "DO host actor requests require the local envelope");
   }
-  const bytes = await readBoundedBytes(request, MAX_INVOKE_ENVELOPE_BYTES);
-  if (bytes.length < 4) {
-    throw new DoRuntimeError(400, "invalid_request", "local actor envelope is truncated");
-  }
-  const metadataLength = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(0, false);
-  if (metadataLength === 0 || 4 + metadataLength > bytes.length) {
-    throw new DoRuntimeError(400, "invalid_request", "local actor envelope metadata is invalid");
-  }
-  let metadata;
-  try {
-    metadata = JSON.parse(utf8Decoder.decode(bytes.subarray(4, 4 + metadataLength)));
-  } catch {
-    throw new DoRuntimeError(400, "invalid_json", "Request body must be valid JSON");
-  }
-  const invoke = normalizeDoInvokeRequest(metadata);
-  const bodyBytes = bytes.subarray(4 + metadataLength);
-  if (bodyBytes.length === 0) return invoke;
-  if (!("request" in invoke)) {
-    throw new DoRuntimeError(400, "invalid_request", "local actor envelope body is only valid for fetch requests");
-  }
-  return {
-    ...invoke,
-    request: {
-      ...invoke.request,
-      bodyBytes,
-    },
-  };
+  const { metadata, bodyBytes } = decodeInvokeEnvelope(
+    await readBoundedBytes(request, MAX_INVOKE_ENVELOPE_BYTES),
+    "local actor envelope",
+  );
+  return invokeWithEnvelopeBody(metadata, bodyBytes, "local actor envelope");
 }
 
-/** @param {Uint8Array} bytes */
-function decodeInvokeEnvelope(bytes) {
+/** @param {Uint8Array} bytes @param {string} [envelopeName] */
+function decodeInvokeEnvelope(bytes, envelopeName = "DO invoke envelope") {
   if (bytes.length < 4) {
-    throw new DoRuntimeError(400, "invalid_request", "DO invoke envelope is truncated");
+    throw new DoRuntimeError(400, "invalid_request", `${envelopeName} is truncated`);
   }
   const metadataLength = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(0, false);
   if (metadataLength === 0 || 4 + metadataLength > bytes.length) {
-    throw new DoRuntimeError(400, "invalid_request", "DO invoke envelope metadata is invalid");
+    throw new DoRuntimeError(400, "invalid_request", `${envelopeName} metadata is invalid`);
   }
   let metadata;
   try {
@@ -725,12 +703,13 @@ function decodeInvokeEnvelope(bytes) {
 /**
  * @param {unknown} metadata
  * @param {Uint8Array} bodyBytes
+ * @param {string} [envelopeName]
  */
-function invokeWithEnvelopeBody(metadata, bodyBytes) {
+function invokeWithEnvelopeBody(metadata, bodyBytes, envelopeName = "DO invoke envelope") {
   const invoke = normalizeDoInvokeRequest(metadata);
   if (bodyBytes.length === 0) return invoke;
   if (!("request" in invoke)) {
-    throw new DoRuntimeError(400, "invalid_request", "DO invoke envelope body is only valid for fetch requests");
+    throw new DoRuntimeError(400, "invalid_request", `${envelopeName} body is only valid for fetch requests`);
   }
   return {
     ...invoke,

--- a/docs/modules/gateway.md
+++ b/docs/modules/gateway.md
@@ -10,8 +10,9 @@ traffic to control without making control aware of gateway topology.
 
 The workerd entrypoint is `gateway/index.js`. Pure route parsing lives in
 `gateway/dispatch.js` and `gateway/lib.js`; static routing-option memoization plus
-Redis/cache/subscriber mechanics live in `gateway/runtime.js`; WebSocket lifetime
-management lives in `gateway/websocket.js`.
+Redis/cache/subscriber mechanics live in `gateway/runtime.js`; process-local WebSocket
+lifecycle admission and reconciliation live in `gateway/websocket-lifecycle.js`; and
+WebSocket transport management lives in `gateway/websocket.js`.
 
 Gateway has three dispatch branches:
 

--- a/docs/modules/gateway.zh.md
+++ b/docs/modules/gateway.zh.md
@@ -6,7 +6,7 @@ Gateway 是公开数据面入口，也是 admin-host 入口 shim。它把 tenant
 
 ## 当前实现
 
-workerd 入口是 `gateway/index.js`。纯 route 解析在 `gateway/dispatch.js` 和 `gateway/lib.js`；静态 routing option memoization 及 Redis/cache/subscriber 逻辑在 `gateway/runtime.js`；WebSocket 生命周期在 `gateway/websocket.js`。
+workerd 入口是 `gateway/index.js`。纯 route 解析在 `gateway/dispatch.js` 和 `gateway/lib.js`；静态 routing option memoization 及 Redis/cache/subscriber 逻辑在 `gateway/runtime.js`；进程内 WebSocket lifecycle admission/reconciliation 在 `gateway/websocket-lifecycle.js`；WebSocket transport management 在 `gateway/websocket.js`。
 
 Gateway 有三条 dispatch 分支：
 

--- a/docs/protocol-contracts.md
+++ b/docs/protocol-contracts.md
@@ -36,7 +36,7 @@ Every protocol shape needs one owning module and one current written source:
 | Route and pattern projections | `shared/route-projection.js`, `control/routing.js`, `gateway/` |
 | D1 query/facade protocol | `docs/modules/d1.md`, `shared/d1-*`, `d1-runtime/`, runtime D1 binding |
 | Durable Object invoke/connect protocol | `docs/modules/durable-objects.md`, `runtime/_wdl-do-transport.js`, `do-runtime/protocol.js` |
-| Durable Object rollout projection and lifecycle notifications | `docs/modules/durable-objects.md`, `shared/worker-contract.js`, `control/routing.js`, `control/handlers/delete-plan.js`, `gateway/runtime.js`, `do-runtime/owner-registry.js`, `rust/workflows/src/api/do_alarms/dispatch.rs` |
+| Durable Object rollout projection and lifecycle notifications | `docs/modules/durable-objects.md`, `shared/worker-contract.js`, `control/routing.js`, `control/handlers/delete-plan.js`, `gateway/runtime.js`, `gateway/websocket-lifecycle.js`, `do-runtime/owner-registry.js`, `rust/workflows/src/api/do_alarms/dispatch.rs` |
 | Queue, cron, and delayed queue records | `docs/modules/queues-cron.md`, `shared/queue-keys.js`, scheduler/proxy Rust modules |
 | Workflow definitions and instance state | `docs/modules/workflows.md`, `rust/workflows/`, runtime workflow dispatch |
 | Observability event and metric shape | `docs/modules/log-tail-observability.md`, `shared/observability.js`, `wdl-rust-common` |

--- a/docs/protocol-contracts.zh.md
+++ b/docs/protocol-contracts.zh.md
@@ -27,7 +27,7 @@
 | Route 和 pattern projection | `shared/route-projection.js`、`control/routing.js`、`gateway/` |
 | D1 query/facade protocol | `docs/modules/d1.zh.md`、`shared/d1-*`、`d1-runtime/`、runtime D1 binding |
 | Durable Object invoke/connect protocol | `docs/modules/durable-objects.zh.md`、`runtime/_wdl-do-transport.js`、`do-runtime/protocol.js` |
-| Durable Object rollout projection 和 lifecycle notification | `docs/modules/durable-objects.zh.md`、`shared/worker-contract.js`、`control/routing.js`、`control/handlers/delete-plan.js`、`gateway/runtime.js`、`do-runtime/owner-registry.js`、`rust/workflows/src/api/do_alarms/dispatch.rs` |
+| Durable Object rollout projection 和 lifecycle notification | `docs/modules/durable-objects.zh.md`、`shared/worker-contract.js`、`control/routing.js`、`control/handlers/delete-plan.js`、`gateway/runtime.js`、`gateway/websocket-lifecycle.js`、`do-runtime/owner-registry.js`、`rust/workflows/src/api/do_alarms/dispatch.rs` |
 | Queue、cron、delayed queue record | `docs/modules/queues-cron.zh.md`、`shared/queue-keys.js`、scheduler/proxy Rust modules |
 | Workflow definition 和 instance state | `docs/modules/workflows.zh.md`、`rust/workflows/`、runtime workflow dispatch |
 | Observability event 和 metric shape | `docs/modules/log-tail-observability.zh.md`、`shared/observability.js`、`wdl-rust-common` |

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -19,8 +19,9 @@ are outside this map unless they own runtime or deployable service behavior.
 | `gateway/index.js` | Gateway worker dispatch branches: admin-host short-circuit, subdomain routing, pattern routing, and routed WebSocket proxy setup. |
 | `gateway/dispatch.js` | Pure gateway dispatch decision tree and route target selection. |
 | `gateway/websocket.js` | Local `WebSocketPair` termination, reconnect forwarding, `101` upgrade preservation, and rollout lifecycle closure. |
-| `gateway/runtime.js` | Gateway static routing-option memoization, route/pattern caches, Redis subscriber invalidation, process-local WebSocket lifecycle registry/reconciliation, atomic route/rollout reads, logging, metrics, and health/metrics snapshots. |
-| `gateway/lib.js` | Pure routing helpers used by workerd and Node tests. |
+| `gateway/runtime.js` | Gateway static routing-option memoization, route/pattern caches, Redis subscriber invalidation, logging, metrics, and health/metrics snapshots. |
+| `gateway/websocket-lifecycle.js` | Process-local WebSocket lifecycle admission, registry/reconciliation, and atomic route/rollout reads. |
+| `gateway/lib.js` | Pure routing helpers and shared routing-state error used by workerd and Node tests. |
 | `runtime/config-user.capnp` | User runtime config: loader `:8081`, internal `:8088`, public-only loaded-worker outbound. |
 | `runtime/config-system.capnp` | System runtime config: loader `:8081`, internal `:8088`, control `:8082`, auth worker, private+public outbound. |
 | `runtime/config-user-local.capnp`, `runtime/config-system-local.capnp` | Local runtime workerd configs compiled for Docker Compose with Envoy-backed private service routes. |

--- a/docs/source-map.zh.md
+++ b/docs/source-map.zh.md
@@ -16,8 +16,9 @@
 | `gateway/index.js` | Gateway worker dispatch 分支：admin-host short-circuit、subdomain routing、pattern routing 和 routed WebSocket proxy setup。 |
 | `gateway/dispatch.js` | 纯 gateway dispatch decision tree 和 route target selection。 |
 | `gateway/websocket.js` | 本地 `WebSocketPair` 终结、reconnect forwarding、`101` upgrade preservation 和 rollout lifecycle closure。 |
-| `gateway/runtime.js` | Gateway 静态 routing-option memoization、route/pattern caches、Redis subscriber invalidation、进程内 WebSocket lifecycle registry/reconciliation、atomic route/rollout reads、logging、metrics 和 health/metrics snapshots。 |
-| `gateway/lib.js` | workerd 和 Node tests 共用的纯 routing helpers。 |
+| `gateway/runtime.js` | Gateway 静态 routing-option memoization、route/pattern caches、Redis subscriber invalidation、logging、metrics 和 health/metrics snapshots。 |
+| `gateway/websocket-lifecycle.js` | 进程内 WebSocket lifecycle admission、registry/reconciliation 和 atomic route/rollout reads。 |
+| `gateway/lib.js` | workerd 和 Node tests 共用的纯 routing helpers 与 routing-state error。 |
 | `runtime/config-user.capnp` | User runtime config：loader `:8081`、internal `:8088`、loaded-worker public-only outbound。 |
 | `runtime/config-system.capnp` | System runtime config：loader `:8081`、internal `:8088`、control `:8082`、auth worker、private+public outbound。 |
 | `runtime/config-user-local.capnp`、`runtime/config-system-local.capnp` | 为 Docker Compose 编译的本地 runtime workerd configs，使用 Envoy-backed private service routes。 |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -336,7 +336,7 @@ The helper directories are deliberately not catch-alls. Keep code inline in
 the test file when:
 
 - it is a single-caller utility specific to that file's domain;
-- it is a Redis write whose payload is a literal shell-escaped string;
+- it is a Redis write whose payload is a literal argv value;
 - it is a one-off Redis mock command that is not shared by another test file;
 - it is a stream-protocol command on DB 1 / DB 2 (e.g. `XADD`, `XPENDING`,
   `XREADGROUP`) that the typed Redis helper does not expose yet;

--- a/docs/testing.zh.md
+++ b/docs/testing.zh.md
@@ -191,7 +191,7 @@ npm install -g @wdl-dev/cli@1.6.1
 两棵 helper 树**有意不当抽屉**。以下情况留在测试文件内：
 
 - 该文件域内的单 caller 工具；
-- 带字面 shell-escape 字符串载荷的 Redis 写操作；
+- 带字面 argv 载荷的 Redis 写操作；
 - 另一个测试文件不共享的一次性 Redis mock command；
 - DB 1 / DB 2 上 typed Redis helper 尚未暴露的 stream 协议命令（如 `XADD`、`XPENDING`、`XREADGROUP`）；
 - 跨两个 caller 但实现语义分叉（如不同 header、不同 request shape）。

--- a/gateway/config.capnp
+++ b/gateway/config.capnp
@@ -36,6 +36,7 @@ const gatewayWorker :Workerd.Worker = (
     (name = "gateway-dispatch", esModule = embed "dispatch.js"),
     (name = "gateway-lib", esModule = embed "lib.js"),
     (name = "gateway-runtime", esModule = embed "runtime.js"),
+    (name = "gateway-websocket-lifecycle", esModule = embed "websocket-lifecycle.js"),
     (name = "gateway-websocket", esModule = embed "websocket.js"),
     (name = "shared-worker-id", esModule = embed "../shared/worker-id.js"),
     (name = "ns-pattern.js", esModule = embed "../shared/ns-pattern.js"),

--- a/gateway/dispatch.js
+++ b/gateway/dispatch.js
@@ -3,7 +3,6 @@ import {
   WORKER_NAME_RE,
   isReservedNs,
   RESERVED_TENANT_NS,
-  ROUTES_ALLOWED_RESERVED_NS,
 } from "shared-ns-pattern";
 import {
   classifyHost,
@@ -170,14 +169,6 @@ export async function resolveGatewayDispatch({
     if (!hit) return notFoundDispatch(route);
 
     namespace = hit.ns;
-    if ((isReservedNs(namespace) && !ROUTES_ALLOWED_RESERVED_NS.has(namespace)) ||
-        RESERVED_TENANT_NS.has(namespace)) {
-      return notFoundDispatch(route, {
-        namespace,
-        worker: hit.worker,
-        version: hit.version,
-      });
-    }
     worker = hit.worker;
     if (!WORKER_NAME_RE.test(worker)) {
       return notFoundDispatch(route, { namespace, worker, version: hit.version });

--- a/gateway/lib.js
+++ b/gateway/lib.js
@@ -24,11 +24,6 @@ export function deleteGatewayInternalHeaders(headers) {
   for (const name of privateHeaders) headers.delete(name);
 }
 
-/** @param {string} s */
-export function escapeRegex(s) {
-  return RegExp.escape(s);
-}
-
 // Strip trailing FQDN dot(s). WHATWG URL preserves them, so without this
 // "example.com." would look up a different Redis key than "example.com"
 // and bypass the platform-domain branch.
@@ -66,7 +61,7 @@ function hostRegex(platformDomain, nsPattern) {
   const key = `${platformDomain}\n${nsPattern}`;
   let re = hostRegexCache.get(key);
   if (!re) {
-    re = new RegExp(`^(${nsPattern})\\.${escapeRegex(platformDomain)}$`);
+    re = new RegExp(`^(${nsPattern})\\.${RegExp.escape(platformDomain)}$`);
     hostRegexCache.set(key, re);
   }
   return re;
@@ -94,9 +89,6 @@ export function classifyHost(hostname, platformDomain, nsPattern) {
  * @param {(ns: string) => boolean} isValidRouteNamespace
  */
 export function sortPatterns(entries, isValidRouteNamespace) {
-  if (typeof isValidRouteNamespace !== "function") {
-    throw new TypeError("sortPatterns requires shared isValidRouteNs");
-  }
   /** @type {PatternEntry[]} */
   const sorted = [];
   /** @type {PatternError[]} */

--- a/gateway/lib.js
+++ b/gateway/lib.js
@@ -14,6 +14,16 @@ const INTERNAL_FORWARD_HEADERS = [
   "x-worker-prefix",
 ];
 
+export class GatewayRoutingUnavailableError extends Error {
+  constructor() {
+    super("Gateway routing state changed throughout the bounded lookup");
+    this.name = "GatewayRoutingUnavailableError";
+    this.status = 503;
+    this.code = "gateway_routing_unavailable";
+    this.publicMessage = "Gateway routing temporarily unavailable";
+  }
+}
+
 /** @param {Headers} headers */
 export function deleteGatewayInternalHeaders(headers) {
   for (const name of INTERNAL_FORWARD_HEADERS) headers.delete(name);

--- a/gateway/runtime.js
+++ b/gateway/runtime.js
@@ -4,10 +4,7 @@
 // dispatch and forwarding decisions.
 
 import {
-  decodeBulk,
-  defaultBackoff,
   RedisClient,
-  RedisReplyError,
   RedisSubscriber,
 } from "shared-redis";
 import { decodePatternProjection } from "shared-route-projection";
@@ -19,8 +16,6 @@ import {
 } from "shared-observability";
 import {
   isValidRouteNs,
-  isValidRuntimeLoadNs,
-  isValidWorkerName,
   platformDomainFromEnv,
 } from "shared-ns-pattern";
 import {
@@ -31,22 +26,19 @@ import {
   ROUTES_CHANNEL,
   ROUTES_FLUSH_CHANNEL,
   WORKER_DELETE_CHANNEL,
-  DURABLE_OBJECT_ROLLOUT_PRESERVE,
-  DURABLE_OBJECT_ROLLOUT_RESTART,
-  durableObjectRolloutKey,
-  parseDurableObjectRolloutEvent,
-  parseDurableObjectRolloutProjection,
-  parseWorkerDeleteEvent,
-  parseVersion,
   patternsKey,
   platformDomainDisabledKey,
   routesKey,
 } from "shared-worker-contract";
 import {
+  GatewayRoutingUnavailableError,
   isPatternInvalidationKey,
   normalizeRequestHost,
   sortPatterns,
 } from "gateway-lib";
+import {
+  createGatewayWebSocketLifecycleManager,
+} from "gateway-websocket-lifecycle";
 
 /**
  * @typedef {import("shared-route-projection").PatternProjection & { slot: string }} PatternEntry
@@ -56,12 +48,6 @@ import {
  * @typedef {{ state: InFlightReadState, epoch: number }} InFlightRead
  * @typedef {{ PLATFORM_DOMAIN?: string, ADMIN_HOST?: string, [key: string]: unknown }} GatewayRoutingEnv
  * @typedef {{ platformDomain: string, normalizedAdminHost: string }} GatewayRoutingOptions
- * @typedef {{ kind: "active", version: string, mode: "preserve" | "restart", restartSequence: number }} ActiveWebSocketLifecycleSnapshot
- * @typedef {{ kind: "inactive" } | ActiveWebSocketLifecycleSnapshot} WebSocketLifecycleSnapshot
- * @typedef {{ restart: () => void, fail: () => void }} WebSocketLifecycleHandlers
- * @typedef {"restart" | "fail" | null} WebSocketLifecycleDisposition
- * @typedef {{ restartSequence: number, notify: (disposition: WebSocketLifecycleDisposition) => void }} WebSocketLifecycleSession
- * @typedef {{ ns: string, worker: string, sessions: Set<WebSocketLifecycleSession> }} WebSocketLifecycleGroup
  */
 
 /** @type {WeakMap<GatewayRoutingEnv, GatewayRoutingOptions>} */
@@ -88,37 +74,10 @@ let subscriberConnected = 0;
 let websocketProxyActiveConnections = 0;
 let websocketProxyDetachedConnections = 0;
 let websocketProxyBufferedMessages = 0;
-/** @type {Map<string, WebSocketLifecycleGroup>} */
-const webSocketLifecycleGroups = new Map();
-/** @type {Set<WebSocketLifecycleGroup>} */
-const webSocketLifecycleReconcilePending = new Set();
-/** @type {Set<WebSocketLifecycleGroup>} */
-const webSocketLifecycleReconcileRetryGroups = new Set();
-/** @type {Promise<void> | null} */
-let webSocketLifecycleReconcile = null;
-/** @type {ReturnType<typeof setTimeout> | null} */
-let webSocketLifecycleReconcileRetryTimer = null;
-let webSocketLifecycleReconcileRetryAttempt = 0;
 const MAX_ROUTE_CACHE_ENTRIES = 10_000;
 const MAX_PATTERN_CACHE_ENTRIES = 10_000;
 const MAX_ROUTING_SNAPSHOT_ATTEMPTS = 5;
-const WEBSOCKET_LIFECYCLE_RECONCILE_CONCURRENCY = 8;
-const GATEWAY_REDIS_COMMAND_TIMEOUT_MS = 2_000;
-const TRANSIENT_REDIS_REPLY_CODES = new Set([
-  "BUSY",
-  "CLUSTERDOWN",
-  "LOADING",
-  "MASTERDOWN",
-  "READONLY",
-  "TRYAGAIN",
-]);
 const utf8Decoder = new TextDecoder();
-const READ_WEBSOCKET_LIFECYCLE_SNAPSHOT_SCRIPT = `
-return {
-  redis.call("HGET", KEYS[1], ARGV[1]),
-  redis.call("GET", KEYS[2])
-}
-`;
 
 export const metrics = new MetricsRegistry();
 export const log = createLogger("gateway");
@@ -139,15 +98,7 @@ export function gatewayRoutingOptionsFromEnv(env) {
   return options;
 }
 
-export class GatewayRoutingUnavailableError extends Error {
-  constructor() {
-    super("Gateway routing state changed throughout the bounded lookup");
-    this.name = "GatewayRoutingUnavailableError";
-    this.status = 503;
-    this.code = "gateway_routing_unavailable";
-    this.publicMessage = "Gateway routing temporarily unavailable";
-  }
-}
+export { GatewayRoutingUnavailableError };
 
 function clearRouteState() {
   routeResetEpoch += 1;
@@ -204,314 +155,34 @@ export function createGatewayRedis(redisAddr) {
   return new RedisClient(redisAddr, { onCommand: onRedisCommand });
 }
 
+const webSocketLifecycle = createGatewayWebSocketLifecycleManager({
+  metrics,
+  log,
+  onRedisCommand,
+});
+
 /** @param {string} redisAddr */
 export function createGatewayLifecycleRedis(redisAddr) {
-  return new RedisClient(redisAddr, {
-    commandTimeoutMs: GATEWAY_REDIS_COMMAND_TIMEOUT_MS,
-    onCommand: onRedisCommand,
-  });
-}
-
-/** @param {unknown} err */
-function isTransientRedisReplyError(err) {
-  return err instanceof RedisReplyError && TRANSIENT_REDIS_REPLY_CODES.has(err.code);
+  return webSocketLifecycle.createRedis(redisAddr);
 }
 
 /**
- * Read the active route and DO rollout projection at one Redis linearization
- * point. Gateway calls this only at WebSocket lifecycle and subscriber-recovery
- * boundaries.
- *
  * @param {RedisClient} redis
  * @param {string} ns
  * @param {string} worker
- * @returns {Promise<WebSocketLifecycleSnapshot>}
  */
-export async function readWebSocketLifecycleSnapshot(redis, ns, worker) {
-  let reply;
-  try {
-    reply = await redis.eval(
-      READ_WEBSOCKET_LIFECYCLE_SNAPSHOT_SCRIPT,
-      [routesKey(ns), durableObjectRolloutKey(ns, worker)],
-      [worker]
-    );
-  } catch (err) {
-    if (err instanceof RedisReplyError && !isTransientRedisReplyError(err)) {
-      throw new GatewayRoutingUnavailableError();
-    }
-    throw err;
-  }
-  if (!Array.isArray(reply) || reply.length !== 2) {
-    throw new GatewayRoutingUnavailableError();
-  }
-  const version = decodeBulk(reply[0]);
-  const rawProjection = decodeBulk(reply[1]);
-  if (version == null && rawProjection == null) return { kind: "inactive" };
-  if (version == null || parseVersion(version) == null) {
-    throw new GatewayRoutingUnavailableError();
-  }
-  if (rawProjection == null) {
-    return {
-      kind: "active",
-      version,
-      mode: DURABLE_OBJECT_ROLLOUT_PRESERVE,
-      restartSequence: 0,
-    };
-  }
-  let projection;
-  try {
-    projection = parseDurableObjectRolloutProjection(rawProjection);
-  } catch {
-    throw new GatewayRoutingUnavailableError();
-  }
-  if (!projection || projection.version !== version) {
-    throw new GatewayRoutingUnavailableError();
-  }
-  return { kind: "active", ...projection };
-}
-
-/** @param {string} ns @param {string} worker */
-function webSocketLifecycleKey(ns, worker) {
-  return `${ns}:${worker}`;
+export function readWebSocketLifecycleSnapshot(redis, ns, worker) {
+  return webSocketLifecycle.readSnapshot(redis, ns, worker);
 }
 
 /**
- * Register one live public WebSocket against the rollout generation observed
- * before its backend upgrade. The registration is process-local and exists
- * only for the lifetime of that connection.
- *
  * @param {string} ns
  * @param {string} worker
  * @param {{ restartSequence: number }} snapshot
- * @param {WebSocketLifecycleHandlers} handlers
+ * @param {{ restart: () => void, fail: () => void }} handlers
  */
 export function registerGatewayWebSocketLifecycle(ns, worker, snapshot, handlers) {
-  const key = webSocketLifecycleKey(ns, worker);
-  let group = webSocketLifecycleGroups.get(key);
-  if (!group) {
-    group = { ns, worker, sessions: new Set() };
-    webSocketLifecycleGroups.set(key, group);
-  }
-  const { promise, resolve } = Promise.withResolvers();
-  // Pub/sub runs in the subscriber request's IoContext. Settling this promise
-  // schedules its continuation back on the WebSocket request's IoContext;
-  // Gateway's compatibility date enables workerd's cross-request settlement.
-  void promise.then((disposition) => {
-    if (disposition === "restart") handlers.restart();
-    if (disposition === "fail") handlers.fail();
-  }).catch((err) => {
-    log("error", "websocket_lifecycle_signal_failed", formatError(err));
-  });
-  const session = { restartSequence: snapshot.restartSequence, notify: resolve };
-  group.sessions.add(session);
-  return () => {
-    const current = webSocketLifecycleGroups.get(key);
-    if (current) {
-      current.sessions.delete(session);
-      if (current.sessions.size === 0) webSocketLifecycleGroups.delete(key);
-    }
-    resolve(null);
-  };
-}
-
-/**
- * Remove before notifying so repeated pub/sub or reconciliation passes cannot
- * deliver the same lifecycle transition twice.
- *
- * @param {WebSocketLifecycleGroup} group
- * @param {WebSocketLifecycleSession} session
- * @param {Exclude<WebSocketLifecycleDisposition, null>} disposition
- */
-function notifyWebSocketLifecycleSession(group, session, disposition) {
-  if (!group.sessions.delete(session)) return;
-  const key = webSocketLifecycleKey(group.ns, group.worker);
-  if (group.sessions.size === 0 && webSocketLifecycleGroups.get(key) === group) {
-    webSocketLifecycleGroups.delete(key);
-  }
-  session.notify(disposition);
-}
-
-/** @param {string} raw */
-function parseWebSocketRolloutEvent(raw) {
-  let event;
-  try {
-    event = parseDurableObjectRolloutEvent(raw);
-  } catch {
-    return null;
-  }
-  if (
-    !isValidRuntimeLoadNs(event.ns) ||
-    !isValidWorkerName(event.worker)
-  ) return null;
-  return event;
-}
-
-/** @param {string} raw */
-function parseWebSocketDeleteEvent(raw) {
-  let event;
-  try {
-    event = parseWorkerDeleteEvent(raw);
-  } catch {
-    return null;
-  }
-  if (!isValidRuntimeLoadNs(event.ns) || !isValidWorkerName(event.worker)) return null;
-  return event;
-}
-
-/** @param {{ ns: string, worker: string, restartSequence: number }} event */
-function webSocketLifecycleGroupForRolloutEvent(event) {
-  const group = webSocketLifecycleGroups.get(webSocketLifecycleKey(event.ns, event.worker));
-  if (!group) return null;
-  for (const session of group.sessions) {
-    if (event.restartSequence > session.restartSequence) return group;
-  }
-  return null;
-}
-
-/**
- * @param {string} redisAddr
- * @param {WebSocketLifecycleGroup[]} groups
- * @returns {Promise<WebSocketLifecycleGroup[]>} groups deferred by transport failures
- */
-async function reconcileGatewayWebSocketLifecycles(redisAddr, groups) {
-  if (groups.length === 0) return [];
-  const redis = createGatewayLifecycleRedis(redisAddr);
-  let nextGroup = 0;
-  /** @type {WebSocketLifecycleGroup[]} */
-  const deferredGroups = [];
-  let firstTransportError = null;
-  async function reconcileNextGroup() {
-    while (true) {
-      const index = nextGroup++;
-      if (index >= groups.length) return;
-      const group = groups[index];
-      // Bind this Redis result only to sessions that existed when the read
-      // started; newer sessions may already have observed a later sequence.
-      const sessions = [...group.sessions];
-      let current;
-      try {
-        current = await readWebSocketLifecycleSnapshot(redis, group.ns, group.worker);
-      } catch (err) {
-        if (err instanceof GatewayRoutingUnavailableError) {
-          for (const session of sessions) {
-            notifyWebSocketLifecycleSession(group, session, "fail");
-          }
-        } else {
-          deferredGroups.push(group);
-          firstTransportError ??= err;
-        }
-        continue;
-      }
-      if (current.kind === "inactive") {
-        for (const session of sessions) {
-          notifyWebSocketLifecycleSession(group, session, "restart");
-        }
-        continue;
-      }
-      for (const session of sessions) {
-        if (current.restartSequence < session.restartSequence) {
-          notifyWebSocketLifecycleSession(group, session, "fail");
-        } else if (current.restartSequence > session.restartSequence) {
-          if (current.mode === DURABLE_OBJECT_ROLLOUT_RESTART) {
-            notifyWebSocketLifecycleSession(group, session, "restart");
-          } else {
-            session.restartSequence = current.restartSequence;
-          }
-        }
-      }
-    }
-  }
-  await Promise.all(
-    Array.from(
-      { length: Math.min(WEBSOCKET_LIFECYCLE_RECONCILE_CONCURRENCY, groups.length) },
-      () => reconcileNextGroup()
-    )
-  );
-  if (deferredGroups.length > 0) {
-    log("warn", "websocket_lifecycle_reconcile_deferred", {
-      deferred_groups: deferredGroups.length,
-      ...(firstTransportError == null ? {} : formatError(firstTransportError)),
-    });
-  }
-  return deferredGroups;
-}
-
-function cancelWebSocketLifecycleReconcileRetry() {
-  if (webSocketLifecycleReconcileRetryTimer !== null) {
-    clearTimeout(webSocketLifecycleReconcileRetryTimer);
-    webSocketLifecycleReconcileRetryTimer = null;
-  }
-  webSocketLifecycleReconcileRetryGroups.clear();
-  webSocketLifecycleReconcileRetryAttempt = 0;
-}
-
-/** @param {string} redisAddr */
-function deferWebSocketLifecycleReconcile(redisAddr) {
-  if (
-    webSocketLifecycleReconcileRetryTimer !== null ||
-    subscriberConnected === 0 ||
-    webSocketLifecycleReconcileRetryGroups.size === 0
-  ) return;
-  const delayMs = defaultBackoff(webSocketLifecycleReconcileRetryAttempt++);
-  webSocketLifecycleReconcileRetryTimer = setTimeout(() => {
-    webSocketLifecycleReconcileRetryTimer = null;
-    for (const group of webSocketLifecycleReconcileRetryGroups) {
-      const key = webSocketLifecycleKey(group.ns, group.worker);
-      if (group.sessions.size > 0 && webSocketLifecycleGroups.get(key) === group) {
-        webSocketLifecycleReconcilePending.add(group);
-      }
-    }
-    webSocketLifecycleReconcileRetryGroups.clear();
-    scheduleWebSocketLifecycleReconcile(redisAddr, []);
-  }, delayMs);
-}
-
-/**
- * @param {string} redisAddr
- * @param {Iterable<WebSocketLifecycleGroup>} [groups]
- */
-function scheduleWebSocketLifecycleReconcile(
-  redisAddr,
-  groups = webSocketLifecycleGroups.values()
-) {
-  for (const group of groups) {
-    const key = webSocketLifecycleKey(group.ns, group.worker);
-    if (group.sessions.size > 0 && webSocketLifecycleGroups.get(key) === group) {
-      webSocketLifecycleReconcilePending.add(group);
-    }
-  }
-  if (webSocketLifecycleReconcilePending.size === 0) {
-    if (!webSocketLifecycleReconcile && webSocketLifecycleReconcileRetryGroups.size === 0) {
-      cancelWebSocketLifecycleReconcileRetry();
-    }
-    return;
-  }
-  if (webSocketLifecycleReconcile) return;
-  /** @type {WebSocketLifecycleGroup[]} */
-  let activeGroups = [];
-  webSocketLifecycleReconcile = (async () => {
-    while (webSocketLifecycleReconcilePending.size > 0) {
-      activeGroups = [...webSocketLifecycleReconcilePending];
-      webSocketLifecycleReconcilePending.clear();
-      for (const group of activeGroups) webSocketLifecycleReconcileRetryGroups.delete(group);
-      const deferred = await reconcileGatewayWebSocketLifecycles(redisAddr, activeGroups);
-      for (const group of deferred) webSocketLifecycleReconcileRetryGroups.add(group);
-    }
-  })()
-    .catch((err) => {
-      for (const group of activeGroups) webSocketLifecycleReconcileRetryGroups.add(group);
-      log("error", "websocket_lifecycle_reconcile_failed", formatError(err));
-    })
-    .finally(() => {
-      webSocketLifecycleReconcile = null;
-      if (webSocketLifecycleReconcilePending.size > 0) {
-        scheduleWebSocketLifecycleReconcile(redisAddr, []);
-      } else if (webSocketLifecycleReconcileRetryGroups.size > 0) {
-        deferWebSocketLifecycleReconcile(redisAddr);
-      } else {
-        cancelWebSocketLifecycleReconcileRetry();
-      }
-    });
+  return webSocketLifecycle.register(ns, worker, snapshot, handlers);
 }
 
 /**
@@ -716,13 +387,12 @@ export function ensureGatewaySubscriber(redisAddr) {
         clearPatternState();
         metrics.increment("subscriber_connects", { service: "gateway" });
         log("info", "subscriber_connected", {});
-        cancelWebSocketLifecycleReconcileRetry();
-        scheduleWebSocketLifecycleReconcile(redisAddr);
+        webSocketLifecycle.onSubscriberConnect(redisAddr);
       },
       onDisconnect: () => {
         if (subscriberConnected === 0) return;
         subscriberConnected = 0;
-        cancelWebSocketLifecycleReconcileRetry();
+        webSocketLifecycle.onSubscriberDisconnect();
         clearRouteState();
         clearPatternState();
         metrics.increment("subscriber_disconnects", { service: "gateway" });
@@ -734,52 +404,11 @@ export function ensureGatewaySubscriber(redisAddr) {
       onMessage: (channel, payload) => {
         const value = utf8Decoder.decode(payload);
         if (channel === DURABLE_OBJECT_ROLLOUT_CHANNEL) {
-          const event = parseWebSocketRolloutEvent(value);
-          if (!event) {
-            log("warn", "websocket_rollout_invalidation_ignored", {
-              reason: "invalid_payload",
-              payload: value.slice(0, 128),
-            });
-            return;
-          }
-          const group = webSocketLifecycleGroupForRolloutEvent(event);
-          const reconciliationRequested = group !== null;
-          if (group) scheduleWebSocketLifecycleReconcile(redisAddr, [group]);
-          metrics.increment("subscriber_invalidations", {
-            service: "gateway",
-            scope: "do_rollout",
-          });
-          log("info", "websocket_rollout_invalidated", {
-            namespace: event.ns,
-            worker: event.worker,
-            version: event.version,
-            restart_sequence: event.restartSequence,
-            reconciliation_requested: reconciliationRequested,
-          });
+          webSocketLifecycle.onRolloutEvent(redisAddr, value);
           return;
         }
         if (channel === WORKER_DELETE_CHANNEL) {
-          const event = parseWebSocketDeleteEvent(value);
-          if (!event) {
-            log("warn", "worker_delete_invalidation_ignored", {
-              reason: "invalid_payload",
-              payload: value.slice(0, 128),
-            });
-            return;
-          }
-          const group = webSocketLifecycleGroups.get(
-            webSocketLifecycleKey(event.ns, event.worker)
-          );
-          if (group) scheduleWebSocketLifecycleReconcile(redisAddr, [group]);
-          metrics.increment("subscriber_invalidations", {
-            service: "gateway",
-            scope: "worker_delete",
-          });
-          log("info", "worker_delete_invalidated", {
-            namespace: event.ns,
-            worker: event.worker,
-            reconciliation_requested: group !== undefined,
-          });
+          webSocketLifecycle.onWorkerDeleteEvent(redisAddr, value);
           return;
         }
         if (channel === PATTERNS_CHANNEL) {

--- a/gateway/websocket-lifecycle.js
+++ b/gateway/websocket-lifecycle.js
@@ -1,0 +1,440 @@
+// Process-local WebSocket lifecycle admission and reconciliation. The Gateway
+// subscriber supplies hints; Redis route/rollout state remains authoritative.
+
+import {
+  decodeBulk,
+  defaultBackoff,
+  RedisClient,
+  RedisReplyError,
+} from "shared-redis";
+import { formatError } from "shared-observability";
+import {
+  isValidRuntimeLoadNs,
+  isValidWorkerName,
+} from "shared-ns-pattern";
+import { GatewayRoutingUnavailableError } from "gateway-lib";
+import {
+  DURABLE_OBJECT_ROLLOUT_PRESERVE,
+  DURABLE_OBJECT_ROLLOUT_RESTART,
+  durableObjectRolloutKey,
+  parseDurableObjectRolloutEvent,
+  parseDurableObjectRolloutProjection,
+  parseWorkerDeleteEvent,
+  parseVersion,
+  routesKey,
+} from "shared-worker-contract";
+
+/**
+ * @typedef {{ kind: "active", version: string, mode: "preserve" | "restart", restartSequence: number }} ActiveWebSocketLifecycleSnapshot
+ * @typedef {{ kind: "inactive" } | ActiveWebSocketLifecycleSnapshot} WebSocketLifecycleSnapshot
+ * @typedef {{ restart: () => void, fail: () => void }} WebSocketLifecycleHandlers
+ * @typedef {"restart" | "fail" | null} WebSocketLifecycleDisposition
+ * @typedef {{ restartSequence: number, notify: (disposition: WebSocketLifecycleDisposition) => void }} WebSocketLifecycleSession
+ * @typedef {{ ns: string, worker: string, sessions: Set<WebSocketLifecycleSession> }} WebSocketLifecycleGroup
+ * @typedef {(level: string, event: string, fields?: Record<string, unknown>) => void} GatewayLogger
+ * @typedef {{ increment(name: string, labels?: Record<string, string | number | boolean>, delta?: number): void }} GatewayMetrics
+ */
+
+const WEBSOCKET_LIFECYCLE_RECONCILE_CONCURRENCY = 8;
+const GATEWAY_REDIS_COMMAND_TIMEOUT_MS = 2_000;
+const TRANSIENT_REDIS_REPLY_CODES = new Set([
+  "BUSY",
+  "CLUSTERDOWN",
+  "LOADING",
+  "MASTERDOWN",
+  "READONLY",
+  "TRYAGAIN",
+]);
+const READ_WEBSOCKET_LIFECYCLE_SNAPSHOT_SCRIPT = `
+return {
+  redis.call("HGET", KEYS[1], ARGV[1]),
+  redis.call("GET", KEYS[2])
+}
+`;
+
+/** @param {unknown} err */
+function isTransientRedisReplyError(err) {
+  return err instanceof RedisReplyError && TRANSIENT_REDIS_REPLY_CODES.has(err.code);
+}
+
+/** @param {string} ns @param {string} worker */
+function webSocketLifecycleKey(ns, worker) {
+  return `${ns}:${worker}`;
+}
+
+/** @param {string} raw */
+function parseWebSocketRolloutEvent(raw) {
+  let event;
+  try {
+    event = parseDurableObjectRolloutEvent(raw);
+  } catch {
+    return null;
+  }
+  if (!isValidRuntimeLoadNs(event.ns) || !isValidWorkerName(event.worker)) return null;
+  return event;
+}
+
+/** @param {string} raw */
+function parseWebSocketDeleteEvent(raw) {
+  let event;
+  try {
+    event = parseWorkerDeleteEvent(raw);
+  } catch {
+    return null;
+  }
+  if (!isValidRuntimeLoadNs(event.ns) || !isValidWorkerName(event.worker)) return null;
+  return event;
+}
+
+/**
+ * @param {{
+ *   metrics: GatewayMetrics,
+ *   log: GatewayLogger,
+ *   onRedisCommand: (event: import("shared-redis").RedisCommandEvent) => void,
+ * }} options
+ */
+export function createGatewayWebSocketLifecycleManager({ metrics, log, onRedisCommand }) {
+  /** @type {Map<string, WebSocketLifecycleGroup>} */
+  const groups = new Map();
+  /** @type {Set<WebSocketLifecycleGroup>} */
+  const reconcilePending = new Set();
+  /** @type {Set<WebSocketLifecycleGroup>} */
+  const reconcileRetryGroups = new Set();
+  /** @type {Promise<void> | null} */
+  let reconciliation = null;
+  /** @type {ReturnType<typeof setTimeout> | null} */
+  let retryTimer = null;
+  let retryAttempt = 0;
+  let subscriberConnected = false;
+
+  /** @param {string} redisAddr */
+  function createRedis(redisAddr) {
+    return new RedisClient(redisAddr, {
+      commandTimeoutMs: GATEWAY_REDIS_COMMAND_TIMEOUT_MS,
+      onCommand: onRedisCommand,
+    });
+  }
+
+  /**
+   * Read the active route and DO rollout projection at one Redis linearization
+   * point. Gateway calls this only at WebSocket lifecycle and subscriber-recovery
+   * boundaries.
+   *
+   * @param {RedisClient} redis
+   * @param {string} ns
+   * @param {string} worker
+   * @returns {Promise<WebSocketLifecycleSnapshot>}
+   */
+  async function readSnapshot(redis, ns, worker) {
+    let reply;
+    try {
+      reply = await redis.eval(
+        READ_WEBSOCKET_LIFECYCLE_SNAPSHOT_SCRIPT,
+        [routesKey(ns), durableObjectRolloutKey(ns, worker)],
+        [worker]
+      );
+    } catch (err) {
+      if (err instanceof RedisReplyError && !isTransientRedisReplyError(err)) {
+        throw new GatewayRoutingUnavailableError();
+      }
+      throw err;
+    }
+    if (!Array.isArray(reply) || reply.length !== 2) {
+      throw new GatewayRoutingUnavailableError();
+    }
+    const version = decodeBulk(reply[0]);
+    const rawProjection = decodeBulk(reply[1]);
+    if (version == null && rawProjection == null) return { kind: "inactive" };
+    if (version == null || parseVersion(version) == null) {
+      throw new GatewayRoutingUnavailableError();
+    }
+    if (rawProjection == null) {
+      return {
+        kind: "active",
+        version,
+        mode: DURABLE_OBJECT_ROLLOUT_PRESERVE,
+        restartSequence: 0,
+      };
+    }
+    let projection;
+    try {
+      projection = parseDurableObjectRolloutProjection(rawProjection);
+    } catch {
+      throw new GatewayRoutingUnavailableError();
+    }
+    if (!projection || projection.version !== version) {
+      throw new GatewayRoutingUnavailableError();
+    }
+    return { kind: "active", ...projection };
+  }
+
+  /**
+   * Register one live public WebSocket against the rollout generation observed
+   * before its backend upgrade. The registration is process-local and exists
+   * only for the lifetime of that connection.
+   *
+   * @param {string} ns
+   * @param {string} worker
+   * @param {{ restartSequence: number }} snapshot
+   * @param {WebSocketLifecycleHandlers} handlers
+   */
+  function register(ns, worker, snapshot, handlers) {
+    const key = webSocketLifecycleKey(ns, worker);
+    let group = groups.get(key);
+    if (!group) {
+      group = { ns, worker, sessions: new Set() };
+      groups.set(key, group);
+    }
+    const { promise, resolve } = Promise.withResolvers();
+    // Pub/sub runs in the subscriber request's IoContext. Settling this promise
+    // schedules its continuation back on the WebSocket request's IoContext;
+    // Gateway's compatibility date enables workerd's cross-request settlement.
+    void promise.then((disposition) => {
+      if (disposition === "restart") handlers.restart();
+      if (disposition === "fail") handlers.fail();
+    }).catch((err) => {
+      log("error", "websocket_lifecycle_signal_failed", formatError(err));
+    });
+    const session = { restartSequence: snapshot.restartSequence, notify: resolve };
+    group.sessions.add(session);
+    return () => {
+      const current = groups.get(key);
+      if (current) {
+        current.sessions.delete(session);
+        if (current.sessions.size === 0) groups.delete(key);
+      }
+      resolve(null);
+    };
+  }
+
+  /**
+   * Remove before notifying so repeated pub/sub or reconciliation passes cannot
+   * deliver the same lifecycle transition twice.
+   *
+   * @param {WebSocketLifecycleGroup} group
+   * @param {WebSocketLifecycleSession} session
+   * @param {Exclude<WebSocketLifecycleDisposition, null>} disposition
+   */
+  function notify(group, session, disposition) {
+    if (!group.sessions.delete(session)) return;
+    const key = webSocketLifecycleKey(group.ns, group.worker);
+    if (group.sessions.size === 0 && groups.get(key) === group) groups.delete(key);
+    session.notify(disposition);
+  }
+
+  /** @param {{ ns: string, worker: string, restartSequence: number }} event */
+  function groupForRolloutEvent(event) {
+    const group = groups.get(webSocketLifecycleKey(event.ns, event.worker));
+    if (!group) return null;
+    for (const session of group.sessions) {
+      if (event.restartSequence > session.restartSequence) return group;
+    }
+    return null;
+  }
+
+  /**
+   * @param {string} redisAddr
+   * @param {WebSocketLifecycleGroup[]} requestedGroups
+   * @returns {Promise<WebSocketLifecycleGroup[]>} groups deferred by transport failures
+   */
+  async function reconcile(redisAddr, requestedGroups) {
+    if (requestedGroups.length === 0) return [];
+    const redis = createRedis(redisAddr);
+    let nextGroup = 0;
+    /** @type {WebSocketLifecycleGroup[]} */
+    const deferredGroups = [];
+    let firstTransportError = null;
+    async function reconcileNextGroup() {
+      while (true) {
+        const index = nextGroup++;
+        if (index >= requestedGroups.length) return;
+        const group = requestedGroups[index];
+        // Bind this Redis result only to sessions that existed when the read
+        // started; newer sessions may already have observed a later sequence.
+        const sessions = [...group.sessions];
+        let current;
+        try {
+          current = await readSnapshot(redis, group.ns, group.worker);
+        } catch (err) {
+          if (err instanceof GatewayRoutingUnavailableError) {
+            for (const session of sessions) notify(group, session, "fail");
+          } else {
+            deferredGroups.push(group);
+            firstTransportError ??= err;
+          }
+          continue;
+        }
+        if (current.kind === "inactive") {
+          for (const session of sessions) notify(group, session, "restart");
+          continue;
+        }
+        for (const session of sessions) {
+          if (current.restartSequence < session.restartSequence) {
+            notify(group, session, "fail");
+          } else if (current.restartSequence > session.restartSequence) {
+            if (current.mode === DURABLE_OBJECT_ROLLOUT_RESTART) {
+              notify(group, session, "restart");
+            } else {
+              session.restartSequence = current.restartSequence;
+            }
+          }
+        }
+      }
+    }
+    await Promise.all(
+      Array.from(
+        {
+          length: Math.min(
+            WEBSOCKET_LIFECYCLE_RECONCILE_CONCURRENCY,
+            requestedGroups.length
+          ),
+        },
+        () => reconcileNextGroup()
+      )
+    );
+    if (deferredGroups.length > 0) {
+      log("warn", "websocket_lifecycle_reconcile_deferred", {
+        deferred_groups: deferredGroups.length,
+        ...(firstTransportError == null ? {} : formatError(firstTransportError)),
+      });
+    }
+    return deferredGroups;
+  }
+
+  function cancelRetry() {
+    if (retryTimer !== null) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+    reconcileRetryGroups.clear();
+    retryAttempt = 0;
+  }
+
+  /** @param {string} redisAddr */
+  function deferReconcile(redisAddr) {
+    if (retryTimer !== null || !subscriberConnected || reconcileRetryGroups.size === 0) return;
+    const delayMs = defaultBackoff(retryAttempt++);
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      for (const group of reconcileRetryGroups) {
+        const key = webSocketLifecycleKey(group.ns, group.worker);
+        if (group.sessions.size > 0 && groups.get(key) === group) {
+          reconcilePending.add(group);
+        }
+      }
+      reconcileRetryGroups.clear();
+      scheduleReconcile(redisAddr, []);
+    }, delayMs);
+  }
+
+  /**
+   * @param {string} redisAddr
+   * @param {Iterable<WebSocketLifecycleGroup>} [requestedGroups]
+   */
+  function scheduleReconcile(redisAddr, requestedGroups = groups.values()) {
+    for (const group of requestedGroups) {
+      const key = webSocketLifecycleKey(group.ns, group.worker);
+      if (group.sessions.size > 0 && groups.get(key) === group) reconcilePending.add(group);
+    }
+    if (reconcilePending.size === 0) {
+      if (!reconciliation && reconcileRetryGroups.size === 0) cancelRetry();
+      return;
+    }
+    if (reconciliation) return;
+    /** @type {WebSocketLifecycleGroup[]} */
+    let activeGroups = [];
+    reconciliation = (async () => {
+      while (reconcilePending.size > 0) {
+        activeGroups = [...reconcilePending];
+        reconcilePending.clear();
+        for (const group of activeGroups) reconcileRetryGroups.delete(group);
+        const deferred = await reconcile(redisAddr, activeGroups);
+        for (const group of deferred) reconcileRetryGroups.add(group);
+      }
+    })()
+      .catch((err) => {
+        for (const group of activeGroups) reconcileRetryGroups.add(group);
+        log("error", "websocket_lifecycle_reconcile_failed", formatError(err));
+      })
+      .finally(() => {
+        reconciliation = null;
+        if (reconcilePending.size > 0) {
+          scheduleReconcile(redisAddr, []);
+        } else if (reconcileRetryGroups.size > 0) {
+          deferReconcile(redisAddr);
+        } else {
+          cancelRetry();
+        }
+      });
+  }
+
+  /** @param {string} redisAddr */
+  function onSubscriberConnect(redisAddr) {
+    subscriberConnected = true;
+    cancelRetry();
+    scheduleReconcile(redisAddr);
+  }
+
+  function onSubscriberDisconnect() {
+    subscriberConnected = false;
+    cancelRetry();
+  }
+
+  /** @param {string} redisAddr @param {string} raw */
+  function onRolloutEvent(redisAddr, raw) {
+    const event = parseWebSocketRolloutEvent(raw);
+    if (!event) {
+      log("warn", "websocket_rollout_invalidation_ignored", {
+        reason: "invalid_payload",
+        payload: raw.slice(0, 128),
+      });
+      return;
+    }
+    const group = groupForRolloutEvent(event);
+    if (group) scheduleReconcile(redisAddr, [group]);
+    metrics.increment("subscriber_invalidations", {
+      service: "gateway",
+      scope: "do_rollout",
+    });
+    log("info", "websocket_rollout_invalidated", {
+      namespace: event.ns,
+      worker: event.worker,
+      version: event.version,
+      restart_sequence: event.restartSequence,
+      reconciliation_requested: group !== null,
+    });
+  }
+
+  /** @param {string} redisAddr @param {string} raw */
+  function onWorkerDeleteEvent(redisAddr, raw) {
+    const event = parseWebSocketDeleteEvent(raw);
+    if (!event) {
+      log("warn", "worker_delete_invalidation_ignored", {
+        reason: "invalid_payload",
+        payload: raw.slice(0, 128),
+      });
+      return;
+    }
+    const group = groups.get(webSocketLifecycleKey(event.ns, event.worker));
+    if (group) scheduleReconcile(redisAddr, [group]);
+    metrics.increment("subscriber_invalidations", {
+      service: "gateway",
+      scope: "worker_delete",
+    });
+    log("info", "worker_delete_invalidated", {
+      namespace: event.ns,
+      worker: event.worker,
+      reconciliation_requested: group !== undefined,
+    });
+  }
+
+  return {
+    createRedis,
+    onRolloutEvent,
+    onSubscriberConnect,
+    onSubscriberDisconnect,
+    onWorkerDeleteEvent,
+    readSnapshot,
+    register,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1606,9 +1606,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/rust/common/src/metrics.rs
+++ b/rust/common/src/metrics.rs
@@ -255,7 +255,8 @@ pub fn labels_map(labels: &[(&str, &str)]) -> BTreeMap<String, String> {
         .collect()
 }
 
-pub fn metric_key(name: &str, labels: &BTreeMap<String, String>) -> String {
+#[cfg(test)]
+fn metric_key(name: &str, labels: &BTreeMap<String, String>) -> String {
     let suffix = labels
         .iter()
         .map(|(key, value)| format!("{key}={value}"))

--- a/rust/redis-proxy/src/kv.rs
+++ b/rust/redis-proxy/src/kv.rs
@@ -345,6 +345,7 @@ async fn query_grouped_hmget_with_raw_byte_budget(
     conn: &mut ConnectionManager,
     remaining: usize,
     commands: &[GroupedHmgetCommand],
+    expected_values: usize,
 ) -> AppResult<(usize, Vec<Option<Vec<u8>>>)> {
     if commands.is_empty() {
         return Ok((0, Vec::new()));
@@ -358,19 +359,12 @@ async fn query_grouped_hmget_with_raw_byte_budget(
         .iter()
         .map(|(redis_key, _, _)| redis_key.as_str())
         .collect::<Vec<_>>();
-    let mut args = Vec::with_capacity(
-        1 + field_counts.len()
-            + commands
-                .iter()
-                .map(|(_, _, fields)| fields.len())
-                .sum::<usize>(),
-    );
+    let mut args = Vec::with_capacity(1 + field_counts.len() + expected_values);
     args.push(remaining_arg.as_str());
     for ((_, _, fields), field_count) in commands.iter().zip(&field_counts) {
         args.push(field_count.as_str());
         args.extend(fields.iter().map(String::as_str));
     }
-    let expected_values = commands.iter().map(|(_, _, fields)| fields.len()).sum();
     let reply = HMGET_WITH_RAW_BYTE_BUDGET
         .prepare_invoke(&keys, &args)
         .invoke_async(conn)
@@ -407,10 +401,10 @@ fn apply_grouped_hmget_response(
     output: &mut [Option<Vec<u8>>],
     budget: &mut RawByteBudget,
     commands: &[GroupedHmgetCommand],
+    expected_values: usize,
     preflight_bytes: usize,
     values: Vec<Option<Vec<u8>>>,
 ) -> AppResult<()> {
-    let expected_values = validate_grouped_hmget_plan(commands, output.len())?;
     if values.len() != expected_values {
         return Err(AppError::internal_error("invalid grouped KV HMGET reply"));
     }
@@ -418,6 +412,8 @@ fn apply_grouped_hmget_response(
     let mut values = values.into_iter();
     for (_, indices, _) in commands {
         for index in indices {
+            // load_grouped_fields_with_raw_byte_budget validated plan cardinality
+            // and every output index before issuing the Redis script.
             let value = values
                 .next()
                 .ok_or_else(|| AppError::internal_error("invalid grouped KV HMGET reply"))?;
@@ -435,13 +431,25 @@ async fn load_grouped_fields_with_raw_byte_budget(
     budget: &mut RawByteBudget,
 ) -> AppResult<Vec<Option<Vec<u8>>>> {
     let mut output = vec![None; output_len];
-    validate_grouped_hmget_plan(&commands, output_len)?;
+    let expected_values = validate_grouped_hmget_plan(&commands, output_len)?;
     // All HSTRLEN calls across every hash precede the first HMGET, so an
     // over-budget payload never leaves Valkey. Actual bytes are rechecked before
     // response encoding as a defense against malformed script replies.
-    let (preflight_bytes, values) =
-        query_grouped_hmget_with_raw_byte_budget(conn, budget.remaining()?, &commands).await?;
-    apply_grouped_hmget_response(&mut output, budget, &commands, preflight_bytes, values)?;
+    let (preflight_bytes, values) = query_grouped_hmget_with_raw_byte_budget(
+        conn,
+        budget.remaining()?,
+        &commands,
+        expected_values,
+    )
+    .await?;
+    apply_grouped_hmget_response(
+        &mut output,
+        budget,
+        &commands,
+        expected_values,
+        preflight_bytes,
+        values,
+    )?;
     Ok(output)
 }
 
@@ -1185,6 +1193,7 @@ mod tests {
             &mut output,
             &mut budget,
             &commands,
+            3,
             3,
             vec![
                 Some(b"ccc".to_vec()),

--- a/rust/redis-proxy/src/secrets.rs
+++ b/rust/redis-proxy/src/secrets.rs
@@ -23,6 +23,9 @@ const SECRET_ENVELOPE_KID_ENV: &str = "SECRET_ENVELOPE_KID";
 const AES_256_KEY_BYTES: usize = 32;
 const AES_GCM_IV_BYTES: usize = 12;
 const AES_GCM_TAG_BYTES: usize = 16;
+// Local AES unwraps do not materially benefit from caching. Keep this cache
+// bounded so a future remote KMS provider can avoid per-read unwrap I/O without
+// changing the secret-envelope read path.
 const DEK_CACHE_LIMIT: usize = 512;
 const DEK_CACHE_SHARDS: usize = 16;
 const DEK_CACHE_SHARD_LIMIT: usize = DEK_CACHE_LIMIT / DEK_CACHE_SHARDS;

--- a/rust/scheduler/src/remote_tick.rs
+++ b/rust/scheduler/src/remote_tick.rs
@@ -49,31 +49,32 @@ async fn read_remote_tick_text(
     })
 }
 
-pub(crate) async fn post_remote_tick(
+pub(crate) async fn post_workflow_tick(
     state: &AppState,
-    host: &str,
-    port: u16,
-    path: &str,
-    request_id_prefix: &str,
-    failure_message: &str,
-) -> SchedulerResult<RemoteTickResponse> {
-    let url = format!("http://{host}:{port}{path}");
-    let request_id = format!("{request_id_prefix}-{}-{}", state.instance_id, now_ms());
+) -> SchedulerResult<Option<RemoteTickResponse>> {
+    let Some(host) = state.config.workflows_host.as_deref() else {
+        return Ok(None);
+    };
+    let url = format!(
+        "http://{}:{}/internal/workflows/tick",
+        host, state.config.workflows_port
+    );
+    let request_id = format!("workflow-tick-{}-{}", state.instance_id, now_ms());
     let started_at_ms = now_ms();
     let response = workflow_tick_request(&state.http, &state.config, &url, &request_id)
         .send()
         .await
-        .map_err(|err| SchedulerError::internal_error(format!("{failure_message}: {err}")))?;
+        .map_err(|err| SchedulerError::internal_error(format!("Workflow tick failed: {err}")))?;
     let status = response.status();
-    let text = read_remote_tick_text(response, failure_message).await?;
+    let text = read_remote_tick_text(response, "Workflow tick failed").await?;
     let body = serde_json::from_str::<JsonValue>(&text).unwrap_or_else(|_| json!({}));
-    Ok(RemoteTickResponse {
+    Ok(Some(RemoteTickResponse {
         request_id,
         started_at_ms,
         status,
         text,
         body,
-    })
+    }))
 }
 
 #[cfg(test)]

--- a/rust/scheduler/src/workflows.rs
+++ b/rust/scheduler/src/workflows.rs
@@ -46,18 +46,9 @@ fn workflow_tick_summary(body: &JsonValue) -> WorkflowTickSummary {
 }
 
 pub(crate) async fn workflows_tick(state: AppState) -> SchedulerResult<WorkflowTickSummary> {
-    let Some(host) = state.config.workflows_host.clone() else {
+    let Some(response) = crate::post_workflow_tick(&state).await? else {
         return Ok(WorkflowTickSummary::default());
     };
-    let response = crate::post_remote_tick(
-        &state,
-        &host,
-        state.config.workflows_port,
-        "/internal/workflows/tick",
-        "workflow-tick",
-        "Workflow tick failed",
-    )
-    .await?;
     let status = response.status;
     let body = response.body;
     let duration_ms = now_ms() - response.started_at_ms;

--- a/rust/supervisor/src/config.rs
+++ b/rust/supervisor/src/config.rs
@@ -94,21 +94,10 @@ pub(crate) fn positive_int_env(prefix: &str, name: &str, fallback: u64) -> u64 {
     positive_or(std::env::var(&key).ok(), fallback)
 }
 
-pub(crate) fn positive_int_env_chained(prefix: &str, names: &[&str], fallback: u64) -> u64 {
-    for name in names {
-        let key = format!("{prefix}{name}");
-        let value = positive_or(std::env::var(&key).ok(), 0);
-        if value > 0 {
-            return value;
-        }
-    }
-    fallback
-}
-
 pub(crate) fn shutdown_timeout_ms(config: &SupervisorConfig) -> u64 {
-    positive_int_env_chained(
+    positive_int_env(
         config.env_prefix,
-        &["SHUTDOWN_TIMEOUT_MS", "WORKERD_STOP_TIMEOUT_MS"],
+        "SHUTDOWN_TIMEOUT_MS",
         DEFAULT_SHUTDOWN_TIMEOUT_MS,
     )
 }

--- a/rust/workflows/src/api.rs
+++ b/rust/workflows/src/api.rs
@@ -87,9 +87,8 @@ use routing::{
     workflow_referrer_member,
 };
 use sharded_dispatch::{
-    DuePromotionConfig, DuePromotionMember, ReadyAdmissionConfig, ReadyAdmissionOutcome,
-    ReadyAdmissionResult, admit_ready_members, due_shards_with_due_members, promote_due_members,
-    remove_ready_member_if_state_missing,
+    ReadyAdmissionConfig, ReadyAdmissionOutcome, ReadyAdmissionResult, admit_ready_members,
+    due_shards_with_due_members, remove_ready_member_if_state_missing,
 };
 pub(crate) use status::{get_instance, list_instances, status_instance};
 use status::{

--- a/rust/workflows/src/api/active_export.rs
+++ b/rust/workflows/src/api/active_export.rs
@@ -90,22 +90,17 @@ pub(super) async fn request_with_active_version(
     Ok(req)
 }
 
-pub(super) async fn verify_workflow_def_values(
+pub(super) async fn verify_workflow_def(
     state: &AppState,
-    ns: &str,
-    worker: &str,
-    workflow_name: &str,
-    workflow_key: &str,
-    _class_name: &str,
+    req: &WorkflowRequest,
 ) -> WorkflowResult<()> {
-    let key = workflow_defs_key(ns, worker);
-    let field = workflow_name.to_string();
+    let key = workflow_defs_key(&req.ns, &req.worker);
     let raw: Option<String> = state
         .control_redis
         .with_conn(async |mut conn| {
             redis::cmd("HGET")
                 .arg(key)
-                .arg(field)
+                .arg(&req.workflow_name)
                 .query_async(&mut conn)
                 .await
         })
@@ -116,7 +111,7 @@ pub(super) async fn verify_workflow_def_values(
     let def: WorkflowDef = serde_json::from_str(&raw).map_err(|err| {
         WorkflowError::invalid_state(format!("Workflow definition is corrupt: {err}"))
     })?;
-    if def.workflow_key != workflow_key {
+    if def.workflow_key != req.workflow_key {
         return Err(WorkflowError::invalid_state(
             "Workflow definition does not match runtime metadata",
         ));
@@ -165,19 +160,4 @@ pub(super) async fn ensure_worker_not_deleting(
         ));
     }
     Ok(())
-}
-
-pub(super) async fn verify_workflow_def(
-    state: &AppState,
-    req: &WorkflowRequest,
-) -> WorkflowResult<()> {
-    verify_workflow_def_values(
-        state,
-        &req.ns,
-        &req.worker,
-        &req.workflow_name,
-        &req.workflow_key,
-        &req.class_name,
-    )
-    .await
 }

--- a/rust/workflows/src/api/sharded_dispatch.rs
+++ b/rust/workflows/src/api/sharded_dispatch.rs
@@ -3,7 +3,6 @@ use std::future::Future;
 
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use wdl_rust_common::redis_eval::StaticRedisScript;
-use wdl_rust_common::time::now_ms;
 
 use crate::{AppState, ShardQueueKeys, WorkflowError, WorkflowResult};
 
@@ -13,18 +12,6 @@ pub(crate) struct ReadyAdmissionConfig {
     pub(crate) batch_size: usize,
     pub(crate) concurrency: usize,
     pub(crate) prune_on_error: bool,
-}
-
-pub(crate) struct DuePromotionConfig {
-    pub(crate) total_limit: usize,
-    pub(crate) per_shard_limit: usize,
-    pub(crate) scan_overfetch_factor: usize,
-}
-
-pub(crate) struct DuePromotionMember {
-    pub(crate) member: String,
-    pub(crate) extra_keys: Vec<String>,
-    pub(crate) extra_args: Vec<String>,
 }
 
 pub(crate) struct ReadyAdmissionOutcome<C> {
@@ -228,114 +215,6 @@ pub(crate) async fn remove_ready_member_if_state_missing(
     )
     .await?;
     Ok(removed == 1)
-}
-
-pub(crate) async fn promote_due_members<F>(
-    app: &AppState,
-    keys: ShardQueueKeys,
-    config: DuePromotionConfig,
-    promote_script: &StaticRedisScript,
-    prepare_member: F,
-) -> WorkflowResult<usize>
-where
-    F: Fn(&str) -> Option<DuePromotionMember> + Copy,
-{
-    if config.total_limit == 0 || config.per_shard_limit == 0 {
-        return Ok(0);
-    }
-    let now = now_ms();
-    let mut moved = 0;
-    for shard in due_shards_with_due_members(app, keys, now).await? {
-        if moved >= config.total_limit {
-            break;
-        }
-        let due = keys.due(shard);
-        let ready = keys.ready(shard);
-        let remaining = config.total_limit - moved;
-        let scan_count = remaining
-            .min(config.per_shard_limit)
-            .saturating_mul(config.scan_overfetch_factor.max(1));
-        let members: Vec<String> = app
-            .redis
-            .with_conn(async |mut conn| {
-                redis::cmd("ZRANGEBYSCORE")
-                    .arg(&due)
-                    .arg("-inf")
-                    .arg(now)
-                    .arg("LIMIT")
-                    .arg(0)
-                    .arg(scan_count)
-                    .query_async(&mut conn)
-                    .await
-            })
-            .await?;
-        if members.is_empty() {
-            continue;
-        }
-
-        let mut candidates = Vec::new();
-        let mut malformed = Vec::new();
-        for member in members {
-            match prepare_member(&member) {
-                Some(candidate) => candidates.push(candidate),
-                None => malformed.push(member),
-            }
-        }
-        if !malformed.is_empty() {
-            app.redis
-                .with_conn({
-                    let due = due.clone();
-                    async move |mut conn| {
-                        redis::cmd("ZREM")
-                            .arg(due)
-                            .arg(malformed)
-                            .query_async::<()>(&mut conn)
-                            .await
-                    }
-                })
-                .await?;
-        }
-        if candidates.is_empty() {
-            continue;
-        }
-
-        let shard_arg = shard.to_string();
-        let now_arg = now.to_string();
-        let mut offset = 0;
-        let mut shard_moved = 0;
-        while moved < config.total_limit
-            && shard_moved < config.per_shard_limit
-            && offset < candidates.len()
-        {
-            let remaining = (config.total_limit - moved).min(config.per_shard_limit - shard_moved);
-            let end = (offset + remaining).min(candidates.len());
-            let results: Vec<i64> = app
-                .redis
-                .with_conn(async |mut conn| {
-                    let mut pipe = redis::pipe();
-                    let script = promote_script.prepare_pipeline(&mut pipe, end - offset);
-                    for candidate in &candidates[offset..end] {
-                        let mut script_keys =
-                            vec![due.as_str(), ready.as_str(), keys.ready_active()];
-                        script_keys.extend(candidate.extra_keys.iter().map(String::as_str));
-                        let mut script_args = vec![
-                            candidate.member.as_str(),
-                            now_arg.as_str(),
-                            shard_arg.as_str(),
-                        ];
-                        script_args.extend(candidate.extra_args.iter().map(String::as_str));
-                        script.append(&mut pipe, &script_keys, &script_args);
-                    }
-                    pipe.query_async(&mut conn).await
-                })
-                .await?;
-            let moved_now = results.into_iter().filter(|value| *value == 1).count();
-            moved += moved_now;
-            shard_moved += moved_now;
-            offset = end;
-        }
-    }
-    Ok(moved)
 }
 
 pub(crate) async fn due_shards_with_due_members(

--- a/rust/workflows/src/api/tick/ready.rs
+++ b/rust/workflows/src/api/tick/ready.rs
@@ -3,9 +3,10 @@ use crate::{
     workflow_shard_queue_keys,
 };
 use wdl_rust_common::redis_eval::StaticRedisScript;
+use wdl_rust_common::time::now_ms;
 
 use super::super::{
-    DuePromotionConfig, DuePromotionMember, eval_script, parse_ready_token, promote_due_members,
+    due_shards_with_due_members, eval_script, parse_ready_token,
     remove_ready_member_if_state_missing,
 };
 pub(super) const REMOVE_READY_TOKEN_IF_TERMINAL_SCRIPT: &str = r#"
@@ -68,24 +69,89 @@ pub(super) struct ReadyTokenIdentity {
 }
 
 pub(super) async fn move_due_tokens(app: &AppState) -> WorkflowResult<usize> {
-    promote_due_members(
-        app,
-        workflow_shard_queue_keys(),
-        DuePromotionConfig {
-            total_limit: WORKFLOW_READY_BATCH_SIZE,
-            per_shard_limit: WORKFLOW_READY_BATCH_SIZE,
-            scan_overfetch_factor: DUE_SCAN_OVERFETCH_FACTOR,
-        },
-        &MOVE_DUE_TOKEN,
-        |token| {
-            parse_ready_token(token).map(|(ns, workflow_key, instance_id)| DuePromotionMember {
-                member: token.to_string(),
-                extra_keys: vec![instance_state_key(&ns, &workflow_key, &instance_id)],
-                extra_args: Vec::new(),
+    let keys = workflow_shard_queue_keys();
+    let now = now_ms();
+    let mut moved = 0;
+    for shard in due_shards_with_due_members(app, keys, now).await? {
+        if moved >= WORKFLOW_READY_BATCH_SIZE {
+            break;
+        }
+        let due = keys.due(shard);
+        let ready = keys.ready(shard);
+        let remaining = WORKFLOW_READY_BATCH_SIZE - moved;
+        let scan_count = remaining.saturating_mul(DUE_SCAN_OVERFETCH_FACTOR);
+        let members: Vec<String> = app
+            .redis
+            .with_conn(async |mut conn| {
+                redis::cmd("ZRANGEBYSCORE")
+                    .arg(&due)
+                    .arg("-inf")
+                    .arg(now)
+                    .arg("LIMIT")
+                    .arg(0)
+                    .arg(scan_count)
+                    .query_async(&mut conn)
+                    .await
             })
-        },
-    )
-    .await
+            .await?;
+        if members.is_empty() {
+            continue;
+        }
+
+        let mut candidates = Vec::new();
+        let mut malformed = Vec::new();
+        for token in members {
+            match parse_ready_token(&token) {
+                Some((ns, workflow_key, instance_id)) => {
+                    candidates.push((token, instance_state_key(&ns, &workflow_key, &instance_id)))
+                }
+                None => malformed.push(token),
+            }
+        }
+        if !malformed.is_empty() {
+            app.redis
+                .with_conn({
+                    let due = due.clone();
+                    async move |mut conn| {
+                        redis::cmd("ZREM")
+                            .arg(due)
+                            .arg(malformed)
+                            .query_async::<()>(&mut conn)
+                            .await
+                    }
+                })
+                .await?;
+        }
+        if candidates.is_empty() {
+            continue;
+        }
+
+        let shard_arg = shard.to_string();
+        let now_arg = now.to_string();
+        let mut offset = 0;
+        while moved < WORKFLOW_READY_BATCH_SIZE && offset < candidates.len() {
+            let remaining = WORKFLOW_READY_BATCH_SIZE - moved;
+            let end = (offset + remaining).min(candidates.len());
+            let results: Vec<i64> = app
+                .redis
+                .with_conn(async |mut conn| {
+                    let mut pipe = redis::pipe();
+                    let script = MOVE_DUE_TOKEN.prepare_pipeline(&mut pipe, end - offset);
+                    for (token, state_key) in &candidates[offset..end] {
+                        script.append(
+                            &mut pipe,
+                            &[due.as_str(), ready.as_str(), keys.ready_active(), state_key],
+                            &[token, now_arg.as_str(), shard_arg.as_str()],
+                        );
+                    }
+                    pipe.query_async(&mut conn).await
+                })
+                .await?;
+            moved += results.into_iter().filter(|value| *value == 1).count();
+            offset = end;
+        }
+    }
+    Ok(moved)
 }
 
 pub(super) async fn remove_ready_token(
@@ -172,12 +238,10 @@ mod tests {
         let source = include_str!("ready.rs");
         let shared_source = include_str!("../sharded_dispatch.rs");
         assert!(source.contains("DUE_SCAN_OVERFETCH_FACTOR"));
-        assert!(source.contains("promote_due_members"));
-        assert!(source.contains("total_limit: WORKFLOW_READY_BATCH_SIZE"));
-        assert!(source.contains("per_shard_limit: WORKFLOW_READY_BATCH_SIZE"));
+        assert!(source.contains("let remaining = WORKFLOW_READY_BATCH_SIZE - moved"));
+        assert!(source.contains("remaining.saturating_mul(DUE_SCAN_OVERFETCH_FACTOR)"));
+        assert!(source.contains("while moved < WORKFLOW_READY_BATCH_SIZE"));
         assert!(shared_source.contains("fn due_shards_with_due_members"));
         assert!(shared_source.contains(r#".cmd("ZRANGEBYSCORE")"#));
-        assert!(shared_source.contains("config.scan_overfetch_factor"));
-        assert!(shared_source.contains("while moved < config.total_limit"));
     }
 }

--- a/rust/workflows/src/tests.rs
+++ b/rust/workflows/src/tests.rs
@@ -702,7 +702,7 @@ fn workflow_step_execution_fences_stay_inside_db2_lua() {
         "step execution must not keep a separate preflight verifier outside the Redis script fence"
     );
     assert!(
-        !source.contains("verify_workflow_def_values"),
+        !source.contains("verify_workflow_def("),
         "step execution must not read DB0 workflow definitions per mutation"
     );
     assert!(

--- a/scripts/integration-environment.js
+++ b/scripts/integration-environment.js
@@ -36,10 +36,17 @@ function isExecutableFile(file) {
  */
 function resolveCommandOnPath(command, env) {
   const pathEnv = env.PATH || "";
+  const extensions = process.platform === "win32"
+    ? (env.PATHEXT || ".EXE;.CMD;.BAT;.COM").split(";")
+    : [""];
   for (const dir of pathEnv.split(path.delimiter)) {
     if (!dir) continue;
-    const candidate = path.join(dir, command);
-    if (isExecutableFile(candidate)) return candidate;
+    for (const ext of extensions) {
+      const candidate = path.join(dir, command + ext.toLowerCase());
+      if (isExecutableFile(candidate)) return candidate;
+      const upperCandidate = path.join(dir, command + ext.toUpperCase());
+      if (upperCandidate !== candidate && isExecutableFile(upperCandidate)) return upperCandidate;
+    }
   }
   return null;
 }

--- a/scripts/integration-environment.js
+++ b/scripts/integration-environment.js
@@ -57,8 +57,8 @@ export function shouldPrepareIntegrationArtifacts(env = process.env) {
 }
 
 /** @param {NodeJS.ProcessEnv} [env] */
-export function composeNoBuildFlag(env = process.env) {
-  return env.WDL_INTEGRATION_NO_BUILD === "1" ? " --no-build" : "";
+export function composeNoBuildArgs(env = process.env) {
+  return env.WDL_INTEGRATION_NO_BUILD === "1" ? ["--no-build"] : [];
 }
 
 /** @param {NodeJS.ProcessEnv} [env] */

--- a/scripts/integration-environment.js
+++ b/scripts/integration-environment.js
@@ -36,17 +36,10 @@ function isExecutableFile(file) {
  */
 function resolveCommandOnPath(command, env) {
   const pathEnv = env.PATH || "";
-  const extensions = process.platform === "win32"
-    ? (env.PATHEXT || ".EXE;.CMD;.BAT;.COM").split(";")
-    : [""];
   for (const dir of pathEnv.split(path.delimiter)) {
     if (!dir) continue;
-    for (const ext of extensions) {
-      const candidate = path.join(dir, command + ext.toLowerCase());
-      if (isExecutableFile(candidate)) return candidate;
-      const upperCandidate = path.join(dir, command + ext.toUpperCase());
-      if (upperCandidate !== candidate && isExecutableFile(upperCandidate)) return upperCandidate;
-    }
+    const candidate = path.join(dir, command);
+    if (isExecutableFile(candidate)) return candidate;
   }
   return null;
 }

--- a/shared/redis-command-client.js
+++ b/shared/redis-command-client.js
@@ -4,7 +4,6 @@ import { RedisSession } from "shared-redis-session";
 import { errorMessage } from "./errors.js";
 import {
   decodeRedisTimeMs,
-  decodeStringArray,
   encodeCommand,
   writeRedisCommands,
   normalizeRedisDb,
@@ -19,7 +18,6 @@ import {
  * @typedef {import("shared-redis-resp").RedisReply} RedisReply
  * @typedef {import("shared-redis-resp").RedisCommandEvent} RedisCommandEvent
  * @typedef {import("shared-redis-resp").RedisXAddOptions} RedisXAddOptions
- * @typedef {import("shared-redis-resp").RedisZRangeByScoreOptions} RedisZRangeByScoreOptions
  * @typedef {import("shared-redis-resp").RedisClientOptions} RedisClientOptions
  */
 
@@ -129,32 +127,6 @@ export class RedisClient extends RedisCommandSurface {
     }
   }
 
-  // SMEMBERS returns a Set of strings: members are always plain text.
-  /** @param {string} key */
-  async smembers(key) {
-    const arr = /** @type {Uint8Array[] | null} */ (await this._exec("SMEMBERS", key));
-    return decodeStringArray(arr);
-  }
-
-  /** @param {string} key @param {string} member */
-  async sismember(key, member) {
-    return (await this._exec("SISMEMBER", key, member)) === 1;
-  }
-
-  // HGETALL returns { fieldName (string) -> valueBytes (Uint8Array) }.
-  // Field names are UTF-8 decoded; values stay as bytes so binary modules
-  // round-trip without loss.
-  /** @param {string} key */
-  async hgetall(key) {
-    const arr = /** @type {Uint8Array[] | null} */ (await this._exec("HGETALL", key));
-    /** @type {Record<string, Uint8Array>} */
-    const obj = {};
-    if (arr) {
-      for (let i = 0; i < arr.length; i += 2) obj[utf8Decoder.decode(arr[i])] = arr[i + 1];
-    }
-    return obj;
-  }
-
   /** @param {string} key */
   async get(key) {
     return /** @type {Uint8Array | null} */ (await this._exec("GET", key));
@@ -217,20 +189,6 @@ export class RedisClient extends RedisCommandSurface {
     for (const [field, value] of Object.entries(fields)) args.push(field, value);
     const result = await this._exec(...args);
     return utf8Decoder.decode(/** @type {Uint8Array} */ (result));
-  }
-
-  /** @param {string} key @param {number|string} min @param {number|string} max @param {RedisZRangeByScoreOptions} [opts] */
-  async zrangebyscore(key, min, max, opts = {}) {
-    const args = ["ZRANGEBYSCORE", key, String(min), String(max)];
-    if (opts.limit) args.push("LIMIT", String(opts.limit[0]), String(opts.limit[1]));
-    const result = /** @type {Uint8Array[] | null} */ (await this._exec(...args));
-    if (!result) return [];
-    return decodeStringArray(result);
-  }
-
-  /** @param {string} key @param {...string} members */
-  async zrem(key, ...members) {
-    return this._exec("ZREM", key, ...members);
   }
 
   /** @param {string} key @param {string} start @param {string} end @param {number} count */

--- a/shared/redis-command-surface.js
+++ b/shared/redis-command-surface.js
@@ -1,6 +1,4 @@
 import {
-  buildHGetExArgs,
-  buildHSetExArgs,
   buildHSetArgs,
   buildSetArgs,
   decodeBulk,
@@ -69,7 +67,7 @@ export class RedisCommandSurface {
 
   /** @param {string} channel @param {RedisArg} message */
   async publish(channel, message) {
-    return this._exec("PUBLISH", channel, message);
+    return /** @type {number} */ (await this._exec("PUBLISH", channel, message));
   }
 
   /** @param {string} cursor @param {string} match @param {number} [count] @returns {Promise<[string, string[]]>} */
@@ -98,15 +96,6 @@ export class RedisCommandSurface {
   async hMGet(key, fields) {
     if (fields.length === 0) return [];
     const arr = /** @type {unknown[] | null} */ (await this._exec("HMGET", key, ...fields));
-    return arr ? arr.map(decodeBulk) : [];
-  }
-
-  /** @param {string} key @param {number} ttlSeconds @param {string[]} fields */
-  async hGetEx(key, ttlSeconds, fields) {
-    if (fields.length === 0) return [];
-    const arr = /** @type {unknown[] | null} */ (
-      await this._exec(...buildHGetExArgs(key, ttlSeconds, fields))
-    );
     return arr ? arr.map(decodeBulk) : [];
   }
 
@@ -243,11 +232,6 @@ export class RedisCommandSurface {
     return /** @type {number} */ (await this._exec(...buildHSetArgs(key, rest)));
   }
 
-  /** @param {string} key @param {number} ttlSeconds @param {Record<string, RedisArg>} fields */
-  async hSetEx(key, ttlSeconds, fields) {
-    return /** @type {number} */ (await this._exec(...buildHSetExArgs(key, ttlSeconds, fields)));
-  }
-
   /** @param {string} key @param {...string} fields */
   async hDel(key, ...fields) {
     return /** @type {number} */ (await this._exec("HDEL", key, ...fields));
@@ -259,23 +243,9 @@ export class RedisCommandSurface {
     return decodeStringArray(arr);
   }
 
-  /** @param {string} key */
-  async hLen(key) {
-    return /** @type {number} */ (await this._exec("HLEN", key));
-  }
-
   /** @param {string} key @param {string} field */
   async hExists(key, field) {
     return (await this._exec("HEXISTS", key, field)) === 1;
-  }
-
-  /** @param {string[]} keys @param {string} field */
-  async hExistsMany(keys, field) {
-    const replies = /** @type {number[]} */ (await this._execPipeline(
-      "HEXISTS_PIPELINE",
-      keys.map((key) => ["HEXISTS", key, field])
-    ));
-    return replies.map((value) => value === 1);
   }
 
   /** @param {Array<[string, string]>} pairs */

--- a/shared/redis-resp.js
+++ b/shared/redis-resp.js
@@ -14,7 +14,6 @@ import { errorMessage } from "./errors.js";
  * @typedef {RedisConnectionOptions & { commandTimeoutMs?: number }} RedisClientOptions
  * @typedef {{ ttl?: number, exat?: number, nx?: boolean, xx?: boolean, ifeq?: RedisArg }} RedisSetOptions
  * @typedef {{ maxlen?: number }} RedisXAddOptions
- * @typedef {{ limit?: [number, number] }} RedisZRangeByScoreOptions
  * @typedef {{ REPLACE?: boolean, replace?: boolean }} RedisCopyOptions
  * @typedef {{ onMessage?: ((channel: string, message: Uint8Array) => void) | null, onConnect?: (() => void) | null, onDisconnect?: (() => void) | null, onError?: ((err: unknown) => void) | null, backoff?: (attempt: number) => number, sleep?: (ms: number) => Promise<void>, connect?: RedisSocketFactory }} RedisSubscriberOptions
  */
@@ -507,29 +506,6 @@ export function buildHSetArgs(key, rest) {
   } else {
     throw new Error("hSet requires (key, field, value) or (key, object)");
   }
-  return args;
-}
-
-/** @param {string} key @param {number} ttlSeconds @param {string[]} fields @returns {RedisCommand} */
-export function buildHGetExArgs(key, ttlSeconds, fields) {
-  return [
-    "HGETEX",
-    key,
-    "EX",
-    String(ttlSeconds),
-    "FIELDS",
-    String(fields.length),
-    ...fields,
-  ];
-}
-
-/** @param {string} key @param {number} ttlSeconds @param {Record<string, RedisArg>} fields @returns {RedisCommand} */
-export function buildHSetExArgs(key, ttlSeconds, fields) {
-  /** @type {RedisCommand} */
-  const args = ["HSETEX", key, "EX", String(ttlSeconds), "FIELDS"];
-  const entries = Object.entries(fields);
-  args.push(String(entries.length));
-  for (const [field, value] of entries) args.push(field, value);
   return args;
 }
 

--- a/shared/redis-session.js
+++ b/shared/redis-session.js
@@ -23,7 +23,6 @@ import { errorMessage } from "./errors.js";
  * @typedef {import("shared-redis-resp").RedisCommandEvent} RedisCommandEvent
  * @typedef {import("shared-redis-resp").RedisHSetArg} RedisHSetArg
  * @typedef {import("shared-redis-resp").RedisSetOptions} RedisSetOptions
- * @typedef {import("shared-redis-resp").RedisXAddOptions} RedisXAddOptions
  * @typedef {import("shared-redis-resp").RedisCopyOptions} RedisCopyOptions
  * @typedef {import("shared-redis-resp").RedisSocket} RedisSocket
  * @typedef {import("shared-redis-resp").RedisConnectionOptions} RedisConnectionOptions
@@ -291,23 +290,6 @@ export class RedisSession extends RedisCommandSurface {
     };
   }
 
-  /** @param {string} hashKey @param {string} stringKey @param {string} setKey */
-  async hGetAllGetSMembers(hashKey, stringKey, setKey) {
-    const [hashReply, valueReply, membersReply] = await this._execPipeline(
-      "HGETALL_GET_SMEMBERS_PIPELINE",
-      [
-        ["HGETALL", hashKey],
-        ["GET", stringKey],
-        ["SMEMBERS", setKey],
-      ]
-    );
-    return {
-      hash: decodeHashObject(/** @type {unknown[] | null} */ (hashReply)),
-      value: decodeBulk(valueReply),
-      members: decodeStringArray(/** @type {unknown[] | null} */ (membersReply)),
-    };
-  }
-
   /**
    * @param {string[]} watchKeys
    * @param {string} hashKey
@@ -483,16 +465,6 @@ export class RedisMulti {
   /** @param {string} key @param {number|string} score @param {string} member */
   zAdd(key, score, member) {
     this._commands.push(["ZADD", key, String(score), member]);
-    return this;
-  }
-  /** @param {string} key @param {Record<string, RedisArg>} fields @param {RedisXAddOptions} [opts] */
-  xAdd(key, fields, opts = {}) {
-    /** @type {RedisCommand} */
-    const args = ["XADD", key];
-    if (opts.maxlen) args.push("MAXLEN", "~", String(opts.maxlen));
-    args.push("*");
-    for (const [field, value] of Object.entries(fields)) args.push(field, value);
-    this._commands.push(args);
     return this;
   }
   /** @param {string} key @param {string|string[]} members */

--- a/shared/redis.js
+++ b/shared/redis.js
@@ -31,7 +31,6 @@ export { RedisSubscriber, defaultBackoff } from "shared-redis-subscriber";
  * @typedef {import("shared-redis-resp").RedisClientOptions} RedisClientOptions
  * @typedef {import("shared-redis-resp").RedisSetOptions} RedisSetOptions
  * @typedef {import("shared-redis-resp").RedisXAddOptions} RedisXAddOptions
- * @typedef {import("shared-redis-resp").RedisZRangeByScoreOptions} RedisZRangeByScoreOptions
  * @typedef {import("shared-redis-resp").RedisCopyOptions} RedisCopyOptions
  * @typedef {import("shared-redis-resp").RedisSubscriberOptions} RedisSubscriberOptions
  */

--- a/system-workers/s3-cleanup/src/index.js
+++ b/system-workers/s3-cleanup/src/index.js
@@ -37,7 +37,6 @@ const MAX_ATTEMPTS = 10;
 const BACKOFF_MAX_MS = 30 * 60_000;
 const BACKOFF_BASE_MS = 60_000;
 const CRON_BATCH = 100;
-const MAX_DELETE_PAGES_PER_RUN = 1;
 const MAX_LIST_PAGES = 1000;
 const PROCESSING_LEASE_MS = 30 * 60_000;
 const DB_BINDING = "S3_CLEANUP_DB";
@@ -445,14 +444,14 @@ export async function processTask(db, s3, taskOrId) {
   try {
     const prefixes = /** @type {string[]} */ (task.prefixes);
     let prefixIndex = task.checkpoint?.prefixIndex ?? 0;
-    let continuationToken = task.checkpoint?.continuationToken ?? null;
-    let pageCount = task.checkpoint?.pageCount ?? 0;
+    const continuationToken = task.checkpoint?.continuationToken ?? null;
+    const pageCount = task.checkpoint?.pageCount ?? 0;
     if (prefixIndex > prefixes.length) {
       throw new Error(
         `s3 cleanup checkpoint prefixIndex ${prefixIndex} exceeds prefix count ${prefixes.length}`
       );
     }
-    for (let page = 0; page < MAX_DELETE_PAGES_PER_RUN && prefixIndex < prefixes.length; page += 1) {
+    if (prefixIndex < prefixes.length) {
       const prefix = prefixes[prefixIndex];
       const r = await deletePrefixPage(s3, prefix, continuationToken);
       // If checkpoint persistence fails after this delete, retry may re-delete
@@ -478,8 +477,6 @@ export async function processTask(db, s3, taskOrId) {
         return S3_CLEANUP_OUTCOME.RETRY;
       }
       prefixIndex += 1;
-      continuationToken = null;
-      pageCount = 0;
     }
     if (prefixIndex < prefixes.length) {
       await saveProgress(db, task.id, {

--- a/tests/helpers/load-auth-index.js
+++ b/tests/helpers/load-auth-index.js
@@ -368,11 +368,11 @@ function patchTemplate(template) {
 export const DELEGATED_ISSUE_TEMPLATES = Object.freeze(
   base.DELEGATED_ISSUE_TEMPLATES.map((template) => Object.freeze(patchTemplate(template)))
 );
-export function createDelegatedIssueTemplateMap(templates = DELEGATED_ISSUE_TEMPLATES) {
-  return base.createDelegatedIssueTemplateMap(templates);
-}
-export function resolveDelegatedIssueTemplate(templateId, configured = createDelegatedIssueTemplateMap()) {
-  return base.resolveDelegatedIssueTemplate(templateId, configured);
+const templatesById = new Map(
+  DELEGATED_ISSUE_TEMPLATES.map((template) => [template.id, template])
+);
+export function resolveDelegatedIssueTemplate(templateId) {
+  return templatesById.get(templateId) ?? base.resolveDelegatedIssueTemplate(templateId);
 }
 `)
     : authLibBaseUrl;

--- a/tests/helpers/mocks/fake-redis.js
+++ b/tests/helpers/mocks/fake-redis.js
@@ -787,18 +787,6 @@ export function createFakeRedisSession(state, options = {}) {
         value: state.strings.get(stringKey) ?? null,
       };
     },
-    /** @param {string} hashKey @param {string} stringKey @param {string} setKey */
-    async hGetAllGetSMembers(hashKey, stringKey, setKey) {
-      expireIfNeeded(state, hashKey, options);
-      expireIfNeeded(state, stringKey, options);
-      expireIfNeeded(state, setKey, options);
-      state.commands.push(["hGetAllGetSMembers", hashKey, stringKey, setKey]);
-      return {
-        hash: { ...(state.hashes.get(hashKey) || {}) },
-        value: state.strings.get(stringKey) ?? null,
-        members: [...(state.sets.get(setKey) || new Set())],
-      };
-    },
     /**
      * @param {string[]} watchKeys
      * @param {string} hashKey

--- a/tests/integration/cron-triggers.test.js
+++ b/tests/integration/cron-triggers.test.js
@@ -641,7 +641,7 @@ test("scheduler sweep(): one bad entry must not block re-seeding the valid ones"
   // Wipe slot buckets so sweep is the only path that can re-seed.
   for (const k of redisKeys("cron-slot:*")) redisDel(k);
 
-  sh("docker compose restart scheduler", { stdio: "pipe" });
+  sh(["docker", "compose", "restart", "scheduler"], { stdio: "pipe" });
 
   await waitUntil("sweep to re-seed every valid ref despite bad neighbors", async () => {
     const slots = redisKeys("cron-slot:*");

--- a/tests/integration/d1-binding.test.js
+++ b/tests/integration/d1-binding.test.js
@@ -267,7 +267,14 @@ test("D1 binding wraps declared named entrypoints for service binding callers", 
   });
 
   await waitUntil("D1 named entrypoint request id log", () => {
-    const logs = sh("docker compose logs --no-color --tail=300 d1-runtime");
+    const logs = sh([
+      "docker",
+      "compose",
+      "logs",
+      "--no-color",
+      "--tail=300",
+      "d1-runtime",
+    ]);
     return logs.includes(`"request_id":"${requestId}"`);
   }, { timeoutMs: 10000, intervalMs: 500 });
 });

--- a/tests/integration/d1-storage-shared-localdisk.test.js
+++ b/tests/integration/d1-storage-shared-localdisk.test.js
@@ -59,10 +59,15 @@ function probeNodeEval(source) {
 
 /** @param {string} service */
 function inspectD1DataMount(service) {
-  const containerId = sh(`COMPOSE_PROFILES=d1-multi docker compose ps -q ${service}`, { stdio: "pipe" }).trim();
+  const containerId = sh(["docker", "compose", "ps", "-q", service], {
+    stdio: "pipe",
+    env: { COMPOSE_PROFILES: "d1-multi" },
+  }).trim();
   assert.ok(containerId, `missing container id for ${service}`);
   const mounts = parseStdoutJson(
-    sh(`docker inspect --format '{{json .Mounts}}' ${containerId}`, { stdio: "pipe" }).trim(),
+    sh(["docker", "inspect", "--format", "{{json .Mounts}}", containerId], {
+      stdio: "pipe",
+    }).trim(),
     `${service} mounts`
   );
   const mount = mounts.find((/** @type {any} */ entry) => entry.Destination === "/data/d1");
@@ -446,7 +451,10 @@ test("same DB survives hard owner loss with write then takeover read confirmatio
     assertStatus(init, 200, "init");
     assert.equal(d1RuntimeProbe("d1-runtime-b", dbKey).owner.taskId, "d1-runtime-a");
 
-    sh("COMPOSE_PROFILES=d1-multi docker compose kill -s KILL d1-runtime-a", { stdio: "pipe" });
+    sh(["docker", "compose", "kill", "-s", "KILL", "d1-runtime-a"], {
+      stdio: "pipe",
+      env: { COMPOSE_PROFILES: "d1-multi" },
+    });
     await waitUntil("takeover to d1-runtime-b after killing a", () => {
       const read = d1RuntimeQuery("d1-runtime-b", {
         namespace: ns,
@@ -529,7 +537,10 @@ test("same DB survives hard owner loss with write then takeover read confirmatio
       { id: "k2", body: "before-kill-c" },
     ]);
 
-    sh("COMPOSE_PROFILES=d1-multi docker compose kill -s KILL d1-runtime-c", { stdio: "pipe" });
+    sh(["docker", "compose", "kill", "-s", "KILL", "d1-runtime-c"], {
+      stdio: "pipe",
+      env: { COMPOSE_PROFILES: "d1-multi" },
+    });
     let survivor = "d1-runtime-b";
     await waitUntil("takeover after killing c", () => {
       for (const candidate of ["d1-runtime-a", "d1-runtime-b"]) {
@@ -618,7 +629,10 @@ test("same DB survives repeated hard owner loss with committed rows intact", {
       });
       assert.deepEqual(finalStatementRows(write), expectedRows);
 
-      sh(`COMPOSE_PROFILES=d1-multi docker compose kill -s KILL ${owner}`, { stdio: "pipe" });
+      sh(["docker", "compose", "kill", "-s", "KILL", owner], {
+        stdio: "pipe",
+        env: { COMPOSE_PROFILES: "d1-multi" },
+      });
       const killedOwner = owner;
       const candidates = services.filter((service) => service !== killedOwner);
       let nextOwner = null;
@@ -689,7 +703,10 @@ test("uncommitted test-hook transaction is not visible after hard owner loss", a
       timeoutMs: 10_000,
       intervalMs: 200,
     });
-    sh(`COMPOSE_PROFILES=d1-multi docker compose kill -s KILL ${owner}`, { stdio: "pipe" });
+    sh(["docker", "compose", "kill", "-s", "KILL", owner], {
+      stdio: "pipe",
+      env: { COMPOSE_PROFILES: "d1-multi" },
+    });
     await hold;
 
     await waitUntil("takeover after killing owner during uncommitted transaction", () => {

--- a/tests/integration/delete-api.test.js
+++ b/tests/integration/delete-api.test.js
@@ -40,7 +40,7 @@ setupIntegrationSuite();
 
 function queueCleanupIntents() {
   const stream = queueStreamKey("__system__", S3_CLEANUP_QUEUE_NAME);
-  const raw = redisCommand(`--raw XRANGE ${stream} - +`, { db: 1 });
+  const raw = redisCommand(["--raw", "XRANGE", stream, "-", "+"], { db: 1 });
   const lines = raw.split("\n").map((l) => l.trim()).filter(Boolean);
   /** @type {Array<{ streamId: string, fields: Record<string, string>, body: any }>} */
   const out = [];

--- a/tests/integration/durable-objects-alarms.test.js
+++ b/tests/integration/durable-objects-alarms.test.js
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   adminFetch,
-  composeUpNoBuildArgs,
+  composeProfileUp,
   composeScale,
   delay,
   deployAndPromote,
@@ -1130,10 +1130,7 @@ test("leased DO alarm redelivers after owner task crash before completion", asyn
         15000
       );
     } finally {
-      sh(
-        ["docker", "compose", "up", "-d", ...composeUpNoBuildArgs(), "--wait", killedTask],
-        { stdio: "pipe", env: { COMPOSE_PROFILES: "do-multi" } }
-      );
+      composeProfileUp("do-multi", ["--wait", killedTask], { stdio: "pipe" });
     }
   });
 });

--- a/tests/integration/durable-objects-alarms.test.js
+++ b/tests/integration/durable-objects-alarms.test.js
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   adminFetch,
-  composeUpNoBuildFlag,
+  composeUpNoBuildArgs,
   composeScale,
   delay,
   deployAndPromote,
@@ -1106,7 +1106,10 @@ test("leased DO alarm redelivers after owner task crash before completion", asyn
     );
 
     try {
-      sh(`COMPOSE_PROFILES=do-multi docker compose kill -s KILL ${killedTask}`, { stdio: "pipe" });
+      sh(["docker", "compose", "kill", "-s", "KILL", killedTask], {
+        stdio: "pipe",
+        env: { COMPOSE_PROFILES: "do-multi" },
+      });
       redisSetDoOwner(ownerKey, { ...owner, leaseExpiresAt: Date.now() - 1000 });
 
       const retryDue = Date.now() - 1000;
@@ -1127,9 +1130,10 @@ test("leased DO alarm redelivers after owner task crash before completion", asyn
         15000
       );
     } finally {
-      sh(`COMPOSE_PROFILES=do-multi docker compose up -d${composeUpNoBuildFlag()} --wait ${killedTask}`, {
-        stdio: "pipe",
-      });
+      sh(
+        ["docker", "compose", "up", "-d", ...composeUpNoBuildArgs(), "--wait", killedTask],
+        { stdio: "pipe", env: { COMPOSE_PROFILES: "do-multi" } }
+      );
     }
   });
 });

--- a/tests/integration/durable-objects-ownership.test.js
+++ b/tests/integration/durable-objects-ownership.test.js
@@ -282,7 +282,10 @@ test("Durable Object committed SQLite state survives hard owner SIGKILL and take
 
     const owner = redisGetDoOwner(ownerKey);
     assert.equal(owner.taskId, "do-runtime-a");
-    sh("COMPOSE_PROFILES=do-multi docker compose kill -s KILL do-runtime-a", { stdio: "pipe" });
+    sh(["docker", "compose", "kill", "-s", "KILL", "do-runtime-a"], {
+      stdio: "pipe",
+      env: { COMPOSE_PROFILES: "do-multi" },
+    });
     redisSetDoOwner(ownerKey, {
       ...owner,
       leaseExpiresAt: Date.now() - 1000,

--- a/tests/integration/gateway-websocket.test.js
+++ b/tests/integration/gateway-websocket.test.js
@@ -106,11 +106,21 @@ const GATEWAY_SOCKET_PROBE = `
 
 /** @returns {GatewaySocketStats} */
 function gatewaySocketStats() {
-  const containerId = sh("docker compose ps -q gateway").trim();
+  const containerId = sh(["docker", "compose", "ps", "-q", "gateway"]).trim();
   assert.match(containerId, /^[0-9a-f]{12,64}$/i, "gateway container id");
   const output = sh(
-    `docker run -i --rm --pull=never --network=none --pid=container:${containerId} ` +
-      "node:24-slim node --input-type=module",
+    [
+      "docker",
+      "run",
+      "-i",
+      "--rm",
+      "--pull=never",
+      "--network=none",
+      `--pid=container:${containerId}`,
+      "node:24-slim",
+      "node",
+      "--input-type=module",
+    ],
     { input: GATEWAY_SOCKET_PROBE }
   );
   const stats = /** @type {GatewaySocketStats} */ (
@@ -209,7 +219,7 @@ async function assertNoGatewayHangSince(since) {
   // Historical lifecycle failures reached abortFromHang within 500 ms. Leave
   // the Gateway idle before reading logs so this check cannot mask the signal.
   await delay(1_000);
-  const logs = sh(`docker compose logs --no-color --since=${since} gateway`);
+  const logs = sh(["docker", "compose", "logs", "--no-color", `--since=${since}`, "gateway"]);
   assert.doesNotMatch(logs, GATEWAY_HANG_PATTERN);
 }
 

--- a/tests/integration/gateway.test.js
+++ b/tests/integration/gateway.test.js
@@ -400,7 +400,7 @@ test("boot race: promote during pre-subscribe window still converges", async () 
 
   // Fresh isolate so onConnect (not onDisconnect) is the only path that
   // can clear a pre-attach cache warm.
-  sh("docker compose restart gateway");
+  sh(["docker", "compose", "restart", "gateway"]);
   await waitForGateway();
 
   // Warm cache before SUBSCRIBE ack, then promote — v2's PUBLISH may be

--- a/tests/integration/helpers/cli.js
+++ b/tests/integration/helpers/cli.js
@@ -25,146 +25,18 @@ export function integrationChildEnv(...overlays) {
 }
 
 /**
- * Integration shell helper commands are intentionally a small Docker/Node command
- * subset. Keep the parser local so child_process never receives an uncontrolled
- * shell command line.
- * @param {string} cmd
- * @returns {Array<{ value: string, quoted: boolean }>}
- */
-function shellWords(cmd) {
-  /** @type {Array<{ value: string, quoted: boolean }>} */
-  const words = [];
-  let current = "";
-  let quote = "";
-  let started = false;
-  let quoted = false;
-  const pushCurrent = () => {
-    if (!started) return;
-    words.push({ value: current, quoted });
-    current = "";
-    started = false;
-    quoted = false;
-  };
-  for (let i = 0; i < cmd.length; i += 1) {
-    const ch = cmd[i];
-    if (quote) {
-      if (ch === quote) {
-        quote = "";
-      } else if (quote === "\"" && ch === "\\" && i + 1 < cmd.length) {
-        const next = cmd[i + 1];
-        if (next === "$" || next === "`" || next === "\"" || next === "\\" || next === "\n") {
-          i += 1;
-          if (next !== "\n") current += next;
-        } else {
-          current += ch;
-        }
-      } else {
-        current += ch;
-      }
-      continue;
-    }
-    if (ch === "'" || ch === "\"") {
-      quote = ch;
-      started = true;
-      quoted = true;
-      continue;
-    }
-    if (/\s/.test(ch)) {
-      pushCurrent();
-      continue;
-    }
-    if (ch === "\\" && i + 1 < cmd.length) {
-      i += 1;
-      started = true;
-      current += cmd[i];
-      continue;
-    }
-    started = true;
-    current += ch;
-  }
-  if (quote) throw new Error("unterminated quote in integration command");
-  pushCurrent();
-  return words;
-}
-
-/**
- * @param {Array<{ value: string, quoted: boolean }>} words
- */
-function splitEnvAssignments(words) {
-  /** @type {Record<string, string>} */
-  const env = {};
-  let index = 0;
-  for (; index < words.length; index += 1) {
-    const word = words[index];
-    if (word.quoted) break;
-    const match = word.value.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
-    if (!match) break;
-    env[match[1]] = match[2];
-  }
-  return { env, argv: words.slice(index) };
-}
-
-/**
- * Model the one shell fallback shape used by integration tests without
- * re-opening arbitrary shell execution.
- * @param {Array<{ value: string, quoted: boolean }>} argv
- */
-function splitMissingFallback(argv) {
-  const fallbackTail = ["2>/dev/null", "||", "echo", "missing"];
-  if (argv.length < fallbackTail.length) return { argv, fallbackOutput: null };
-  const tail = argv.slice(-fallbackTail.length);
-  if (!tail.every((word, index) => !word.quoted && word.value === fallbackTail[index])) {
-    return { argv, fallbackOutput: null };
-  }
-  return {
-    argv: argv.slice(0, -fallbackTail.length),
-    fallbackOutput: "missing\n",
-  };
-}
-
-/**
- * Fail closed on shell syntax that this helper has not explicitly modeled.
- * @param {Array<{ value: string, quoted: boolean }>} argv
- */
-function assertSupportedIntegrationSyntax(argv) {
-  for (const word of argv) {
-    if (word.quoted) continue;
-    if (word.value === "||" || word.value === "&&" || word.value === ";" || word.value === "|") {
-      throw new Error(`unsupported integration shell syntax: ${word.value}`);
-    }
-    if (/^(?:\d*)?(?:>>?|<<?)/.test(word.value)) {
-      throw new Error(`unsupported integration shell redirection: ${word.value}`);
-    }
-  }
-}
-
-/** @param {string} cmd */
-export function parseIntegrationCommandForTest(cmd) {
-  const { env, argv: rawArgv } = splitEnvAssignments(shellWords(cmd));
-  const { argv, fallbackOutput } = splitMissingFallback(rawArgv);
-  assertSupportedIntegrationSyntax(argv);
-  return {
-    env,
-    argv: argv.map((word) => word.value),
-    quoted: argv.map((word) => word.quoted),
-    fallbackOutput,
-  };
-}
-
-/**
  * @param {string} program
  * @param {string[]} args
  * @param {{ cwd?: string, input?: string | Buffer, stdio?: any, env?: NodeJS.ProcessEnv }} opts
- * @param {Record<string, string>} cmdEnv
  */
-function spawnIntegrationCommand(program, args, opts, cmdEnv) {
+function spawnIntegrationCommand(program, args, opts) {
   /** @type {import("node:child_process").SpawnSyncOptionsWithStringEncoding} */
   const spawnOptions = {
     cwd: opts.cwd || ROOT,
     stdio: opts.stdio || "pipe",
     encoding: "utf8",
     input: opts.input,
-    env: integrationChildEnv(opts.env || {}, cmdEnv),
+    env: integrationChildEnv(opts.env || {}),
   };
   if (program === "docker") {
     return spawnSync("docker", args, spawnOptions);
@@ -176,24 +48,19 @@ function spawnIntegrationCommand(program, args, opts, cmdEnv) {
 }
 
 /**
- * @param {string} cmd
+ * @param {string[]} argv
  * @param {{ cwd?: string, input?: string | Buffer, stdio?: any, env?: NodeJS.ProcessEnv }} [opts]
  */
-export function sh(cmd, opts = {}) {
-  const { env: cmdEnv, argv: rawArgv } = splitEnvAssignments(shellWords(cmd));
-  const { argv, fallbackOutput } = splitMissingFallback(rawArgv);
-  assertSupportedIntegrationSyntax(argv);
-  const [programToken, ...argTokens] = argv;
-  const program = programToken?.value;
-  const args = argTokens.map((word) => word.value);
+export function sh(argv, opts = {}) {
+  const [program, ...args] = argv;
   if (!program) throw new Error("empty integration command");
-  const res = spawnIntegrationCommand(program, args, opts, cmdEnv);
+  const res = spawnIntegrationCommand(program, args, opts);
   if (res.error) throw res.error;
-  if (res.status !== 0 && fallbackOutput != null) {
-    return fallbackOutput;
-  }
   if (res.status !== 0) {
-    throw new Error(`integration command failed (${res.status}): ${(res.stderr || res.stdout || cmd).trim()}`);
+    const command = argv.join(" ");
+    throw new Error(
+      `integration command failed (${res.status}): ${(res.stderr || res.stdout || command).trim()}`
+    );
   }
   return res.stdout || "";
 }

--- a/tests/integration/helpers/compose.js
+++ b/tests/integration/helpers/compose.js
@@ -1,19 +1,15 @@
 import { spawn } from "node:child_process";
 
-import { composeNoBuildFlag } from "../../../scripts/integration-environment.js";
+import { composeNoBuildArgs } from "../../../scripts/integration-environment.js";
 import { ROOT } from "./env.js";
 import { sh } from "./cli.js";
-
-export function composeUpNoBuildArgs() {
-  return composeNoBuildFlag() ? ["--no-build"] : [];
-}
 
 /**
  * @param {string[]} args
  * @param {{ stdio?: any }} [opts]
  */
 export function composeUp(args, opts = {}) {
-  return sh(["docker", "compose", "up", "-d", ...composeUpNoBuildArgs(), ...args], opts);
+  return sh(["docker", "compose", "up", "-d", ...composeNoBuildArgs(), ...args], opts);
 }
 
 /**
@@ -23,7 +19,7 @@ export function composeUp(args, opts = {}) {
  */
 export function composeProfileUp(profile, args, opts = {}) {
   return sh(
-    ["docker", "compose", "up", "-d", ...composeUpNoBuildArgs(), ...args],
+    ["docker", "compose", "up", "-d", ...composeNoBuildArgs(), ...args],
     { ...opts, env: { ...opts.env, COMPOSE_PROFILES: profile } }
   );
 }

--- a/tests/integration/helpers/compose.js
+++ b/tests/integration/helpers/compose.js
@@ -4,30 +4,33 @@ import { composeNoBuildFlag } from "../../../scripts/integration-environment.js"
 import { ROOT } from "./env.js";
 import { sh } from "./cli.js";
 
-export function composeUpNoBuildFlag() {
-  return composeNoBuildFlag();
+export function composeUpNoBuildArgs() {
+  return composeNoBuildFlag() ? ["--no-build"] : [];
 }
 
 /**
- * @param {string} args
+ * @param {string[]} args
  * @param {{ stdio?: any }} [opts]
  */
 export function composeUp(args, opts = {}) {
-  return sh(`docker compose up -d${composeUpNoBuildFlag()} ${args}`.trimEnd(), opts);
+  return sh(["docker", "compose", "up", "-d", ...composeUpNoBuildArgs(), ...args], opts);
 }
 
 /**
  * @param {string} profile
- * @param {string} args
+ * @param {string[]} args
  * @param {{ stdio?: any, env?: NodeJS.ProcessEnv }} [opts]
  */
 export function composeProfileUp(profile, args, opts = {}) {
-  return sh(`COMPOSE_PROFILES=${profile} docker compose up -d${composeUpNoBuildFlag()} ${args}`, opts);
+  return sh(
+    ["docker", "compose", "up", "-d", ...composeUpNoBuildArgs(), ...args],
+    { ...opts, env: { ...opts.env, COMPOSE_PROFILES: profile } }
+  );
 }
 
 /** @param {Record<string, string | number | boolean>} env */
 function composeEnvArgs(env) {
-  return Object.entries(env).map(([key, value]) => `-e ${key}=${String(value)}`).join(" ");
+  return Object.entries(env).flatMap(([key, value]) => ["-e", `${key}=${String(value)}`]);
 }
 
 const TEST_PROBE_SERVICE = "test-probe";
@@ -38,10 +41,9 @@ const TEST_PROBE_SERVICE = "test-probe";
  */
 export function runProbeNode(script, { env = {} } = {}) {
   const envArgs = composeEnvArgs(env);
-  return sh(
-    `docker compose exec -T${envArgs ? ` ${envArgs}` : ""} ${TEST_PROBE_SERVICE} node`,
-    { input: script }
-  );
+  return sh(["docker", "compose", "exec", "-T", ...envArgs, TEST_PROBE_SERVICE, "node"], {
+    input: script,
+  });
 }
 
 /**
@@ -74,36 +76,36 @@ export function runProbeNodeAsync(script, { env = {}, input = "", evalScript = f
   });
 }
 
-/** @param {string} service @param {string} cmd */
-export function composeExec(service, cmd) {
-  return sh(`docker compose exec -T ${service} ${cmd}`);
+/** @param {string} service @param {string[]} args */
+export function composeExec(service, args) {
+  return sh(["docker", "compose", "exec", "-T", service, ...args]);
 }
 
 /** @param {string} service */
 export function composeStop(service) {
-  return sh(`docker compose stop ${service}`);
+  return sh(["docker", "compose", "stop", service]);
 }
 
 /** @param {string} service */
 export function composeStart(service) {
-  return sh(`docker compose start ${service}`);
+  return sh(["docker", "compose", "start", service]);
 }
 
 /** @param {string} service */
 export function composeRestart(service) {
-  sh(`docker compose restart ${service}`);
-  return composeUp(`--wait ${service}`);
+  sh(["docker", "compose", "restart", service]);
+  return composeUp(["--wait", service]);
 }
 
 /** @param {string} service @param {number} replicas */
 export function composeScale(service, replicas) {
-  return composeUp(`--wait --scale ${service}=${replicas} ${service}`);
+  return composeUp(["--wait", "--scale", `${service}=${replicas}`, service]);
 }
 
 /** @param {string} service */
 export function composeRecreate(service) {
-  sh(`docker compose rm -sf ${service}`);
-  return composeUp(`--wait ${service}`);
+  sh(["docker", "compose", "rm", "-sf", service]);
+  return composeUp(["--wait", service]);
 }
 
 /**

--- a/tests/integration/helpers/d1-runtime.js
+++ b/tests/integration/helpers/d1-runtime.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { adminPost, deployAndPromote } from "./admin-http.js";
-import { composeUp, composeUpNoBuildArgs } from "./compose.js";
+import { composeProfileUp, composeUp } from "./compose.js";
 import { ensureD1SingleRuntime, recreateD1MultiRuntimes } from "./runtimes.js";
 import { gatewayFetch } from "./gateway-http.js";
 import {
@@ -202,18 +202,10 @@ export function restoreD1MultiTasks() {
 }
 
 export function startD1EnvoyOwnerPair() {
-  return sh(
-    [
-      "docker",
-      "compose",
-      "up",
-      "-d",
-      ...composeUpNoBuildArgs(),
-      "--force-recreate",
-      "--wait",
-      "d1-runtime-a",
-    ],
-    { stdio: "pipe", env: { COMPOSE_PROFILES: "d1-multi" } }
+  return composeProfileUp(
+    "d1-multi",
+    ["--force-recreate", "--wait", "d1-runtime-a"],
+    { stdio: "pipe" }
   );
 }
 

--- a/tests/integration/helpers/d1-runtime.js
+++ b/tests/integration/helpers/d1-runtime.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { adminPost, deployAndPromote } from "./admin-http.js";
-import { composeUp, composeUpNoBuildFlag } from "./compose.js";
+import { composeUp, composeUpNoBuildArgs } from "./compose.js";
 import { ensureD1SingleRuntime, recreateD1MultiRuntimes } from "./runtimes.js";
 import { gatewayFetch } from "./gateway-http.js";
 import {
@@ -202,21 +202,34 @@ export function restoreD1MultiTasks() {
 }
 
 export function startD1EnvoyOwnerPair() {
-  return sh(`COMPOSE_PROFILES=d1-multi docker compose up -d${composeUpNoBuildFlag()} --force-recreate --wait d1-runtime-a`, {
-    stdio: "pipe",
-  });
+  return sh(
+    [
+      "docker",
+      "compose",
+      "up",
+      "-d",
+      ...composeUpNoBuildArgs(),
+      "--force-recreate",
+      "--wait",
+      "d1-runtime-a",
+    ],
+    { stdio: "pipe", env: { COMPOSE_PROFILES: "d1-multi" } }
+  );
 }
 
 export function stopD1EnvoyOwnerPair() {
-  return sh("COMPOSE_PROFILES=d1-multi docker compose rm -sf d1-runtime-a", { stdio: "pipe" });
+  return sh(["docker", "compose", "rm", "-sf", "d1-runtime-a"], {
+    stdio: "pipe",
+    env: { COMPOSE_PROFILES: "d1-multi" },
+  });
 }
 
 export function stopD1Router() {
-  return sh("docker compose stop d1-runtime", { stdio: "pipe" });
+  return sh(["docker", "compose", "stop", "d1-runtime"], { stdio: "pipe" });
 }
 
 export function startD1Router() {
-  return composeUp("--wait d1-runtime", { stdio: "pipe" });
+  return composeUp(["--wait", "d1-runtime"], { stdio: "pipe" });
 }
 
 export function restoreD1SingleRuntime() {

--- a/tests/integration/helpers/index.js
+++ b/tests/integration/helpers/index.js
@@ -1,7 +1,7 @@
 export { ADMIN_HOST_HEADER, ADMIN_TOKEN, ASSETS_CDN_BASE, CONTROL_URL, GATEWAY_HOST, GATEWAY_PORT, ROOT, S3MOCK_HOST, S3MOCK_PORT, WDL_CLI_BIN } from "./env.js";
 export { assertNotStatus, assertStatus, assertStatusIn } from "./assertions.js";
 export { assertOk, sh, runWdlCli } from "./cli.js";
-export { composeExec, composeProfileUp, composeRecreate, composeRestart, composeScale, composeStart, composeStop, composeUp, composeUpNoBuildFlag, runProbeNode, runProbeNodeAsync, withServiceStopped } from "./compose.js";
+export { composeExec, composeProfileUp, composeRecreate, composeRestart, composeScale, composeStart, composeStop, composeUp, composeUpNoBuildArgs, runProbeNode, runProbeNodeAsync, withServiceStopped } from "./compose.js";
 export { ensureD1SingleRuntime, ensureDoSingleRuntime, recreateD1MultiRuntimes, recreateDoMultiRuntimes, startDoOwnerTask, stopD1MultiRuntimes, stopDoMultiRuntimes, stopDoOwnerTask, withDoMultiRuntimes, withDoOwnerTask } from "./runtimes.js";
 export { envoyStat, internalHttpRequest, runtimeDispatchPost, runtimeInternalGet, runtimeInternalGetWithHeaders, runtimeInternalPost, schedulerMetricsText, serviceInternalGet, serviceInternalPost, serviceInternalPostAsync, serviceInternalPostLarge, systemRuntimeInternalPost } from "./internal-http.js";
 export { encodeClientBinaryFrame, encodeClientCloseFrame, encodeClientCloseFrameWithoutStatus, encodeClientTextFrame, frameJson, hostWsHandshake, readJsonServerFrame, readOneServerBinaryFrame, readOneServerCloseFrame, readOneServerTextFrame, serviceWebSocketRoundTrip, wsHandshake } from "./websocket.js";
@@ -12,6 +12,5 @@ export { assertIntegrationJson, readIntegrationJson, responseJson, responseJsonO
 export { parseBase64Json, parseJsonText, parseStdoutJson } from "./json-payload.js";
 export { structuredServiceLogEvents } from "./structured-logs.js";
 export { cronId, readMeta } from "./misc.js";
-export { shellQuote } from "./shell-quote.js";
 export { workerFetchCallerSource } from "./worker-source.js";
 export { encodeQueueMessageBody, queueConsumerKey, QUEUE_CONSUMER_INDEX_KEY, queueDelayedKey, queueDelayedMessageMember, QUEUE_DELAYED_INDEX_KEY, QUEUE_DELAYED_WAKE_STREAM, queueDlqKey, QUEUE_STREAM_INDEX_KEY, queueOrphanedKey, queueStreamKey, queueStreamMessage, queueStreamMessageFields } from "./queue.js";

--- a/tests/integration/helpers/index.js
+++ b/tests/integration/helpers/index.js
@@ -1,7 +1,7 @@
 export { ADMIN_HOST_HEADER, ADMIN_TOKEN, ASSETS_CDN_BASE, CONTROL_URL, GATEWAY_HOST, GATEWAY_PORT, ROOT, S3MOCK_HOST, S3MOCK_PORT, WDL_CLI_BIN } from "./env.js";
 export { assertNotStatus, assertStatus, assertStatusIn } from "./assertions.js";
 export { assertOk, sh, runWdlCli } from "./cli.js";
-export { composeExec, composeProfileUp, composeRecreate, composeRestart, composeScale, composeStart, composeStop, composeUp, composeUpNoBuildArgs, runProbeNode, runProbeNodeAsync, withServiceStopped } from "./compose.js";
+export { composeExec, composeProfileUp, composeRecreate, composeRestart, composeScale, composeStart, composeStop, composeUp, runProbeNode, runProbeNodeAsync, withServiceStopped } from "./compose.js";
 export { ensureD1SingleRuntime, ensureDoSingleRuntime, recreateD1MultiRuntimes, recreateDoMultiRuntimes, startDoOwnerTask, stopD1MultiRuntimes, stopDoMultiRuntimes, stopDoOwnerTask, withDoMultiRuntimes, withDoOwnerTask } from "./runtimes.js";
 export { envoyStat, internalHttpRequest, runtimeDispatchPost, runtimeInternalGet, runtimeInternalGetWithHeaders, runtimeInternalPost, schedulerMetricsText, serviceInternalGet, serviceInternalPost, serviceInternalPostAsync, serviceInternalPostLarge, systemRuntimeInternalPost } from "./internal-http.js";
 export { encodeClientBinaryFrame, encodeClientCloseFrame, encodeClientCloseFrameWithoutStatus, encodeClientTextFrame, frameJson, hostWsHandshake, readJsonServerFrame, readOneServerBinaryFrame, readOneServerCloseFrame, readOneServerTextFrame, serviceWebSocketRoundTrip, wsHandshake } from "./websocket.js";

--- a/tests/integration/helpers/queue-scenarios.js
+++ b/tests/integration/helpers/queue-scenarios.js
@@ -14,7 +14,7 @@ export function setupQueueIntegrationSuite() {
       // Restart scheduler to drop any stale queueBlockClient / registry state
       // that might linger from prior test files.
       redisFlushAll();
-      sh("docker compose restart scheduler", { stdio: "pipe" });
+      sh(["docker", "compose", "restart", "scheduler"], { stdio: "pipe" });
       await waitForScheduler();
     },
   });

--- a/tests/integration/helpers/redis.js
+++ b/tests/integration/helpers/redis.js
@@ -4,16 +4,15 @@
 
 import { composeExec } from "./compose.js";
 import { parseJsonText } from "./json-payload.js";
-import { shellQuote } from "./shell-quote.js";
 
 /**
- * @param {string} args
+ * @param {string[]} args
  * @param {{ db?: number }} [options]
  * @returns {string}
  */
 export function redisCommand(args, options = {}) {
-  const dbArgs = options.db == null ? "" : `-n ${options.db} `;
-  return composeExec("redis", `redis-cli ${dbArgs}${args}`).trim();
+  const dbArgs = options.db == null ? [] : ["-n", String(options.db)];
+  return composeExec("redis", ["redis-cli", ...dbArgs, ...args]).trim();
 }
 
 /**
@@ -24,29 +23,28 @@ export function redisCommand(args, options = {}) {
  * @returns {string}
  */
 export function redisEval(script, keys, args, options = {}) {
-  const encoded = [script, String(keys.length), ...keys, ...args].map(shellQuote).join(" ");
-  return redisCommand(`EVAL ${encoded}`, options);
+  return redisCommand(["EVAL", script, String(keys.length), ...keys, ...args], options);
 }
 
 /** @param {string} key @param {{ db?: number }} [options] @returns {string | null} */
 export function redisGet(key, options = {}) {
-  const val = redisCommand(`GET ${shellQuote(key)}`, options);
+  const val = redisCommand(["GET", key], options);
   return val === "" ? null : val;
 }
 
 /** @param {string} key @param {{ db?: number }} [options] @returns {boolean} */
 export function redisExists(key, options = {}) {
-  return redisCommand(`EXISTS ${shellQuote(key)}`, options) === "1";
+  return redisCommand(["EXISTS", key], options) === "1";
 }
 
 /** @param {string[]} keys @param {{ db?: number }} [options] @returns {number} */
 export function redisExistsCount(keys, options = {}) {
-  return Number(redisCommand(`EXISTS ${keys.map(shellQuote).join(" ")}`, options));
+  return Number(redisCommand(["EXISTS", ...keys], options));
 }
 
 /** @param {string} key @param {{ db?: number }} [options] @returns {string | null} */
 export function redisGetRaw(key, options = {}) {
-  const val = redisCommand(`--raw GET ${shellQuote(key)}`, options);
+  const val = redisCommand(["--raw", "GET", key], options);
   return val === "" ? null : val;
 }
 
@@ -74,20 +72,17 @@ export function redisJsonMembers(members, label = "Redis member JSON") {
 
 /** @param {string} key @param {string} value @param {{ db?: number }} [options] */
 export function redisSet(key, value, options = {}) {
-  redisCommand(`SET ${shellQuote(key)} ${shellQuote(value)}`, options);
+  redisCommand(["SET", key, value], options);
 }
 
 /** @param {string} key @param {string} value @param {string} expected @param {{ db?: number }} [options] */
 export function redisSetIfEq(key, value, expected, options = {}) {
-  return redisCommand(
-    `SET ${shellQuote(key)} ${shellQuote(value)} IFEQ ${shellQuote(expected)}`,
-    options
-  ) === "OK";
+  return redisCommand(["SET", key, value, "IFEQ", expected], options) === "OK";
 }
 
 /** @param {string} key @param {string} expected @param {{ db?: number }} [options] */
 export function redisDelIfEq(key, expected, options = {}) {
-  return Number(redisCommand(`DELIFEQ ${shellQuote(key)} ${shellQuote(expected)}`, options));
+  return Number(redisCommand(["DELIFEQ", key, expected], options));
 }
 
 /** @param {string} key @param {unknown} value @param {{ db?: number }} [options] */
@@ -97,7 +92,7 @@ export function redisSetJson(key, value, options = {}) {
 
 /** @param {string} key @param {{ db?: number }} [options] @returns {Record<string, string>} */
 export function redisHGetAll(key, options = {}) {
-  const out = redisCommand(`HGETALL ${shellQuote(key)}`, options);
+  const out = redisCommand(["HGETALL", key], options);
   if (!out) return {};
   const parts = out.split("\n");
   /** @type {Record<string, string>} */
@@ -110,16 +105,15 @@ export function redisHGetAll(key, options = {}) {
 
 /** @param {string} key @param {string} field @param {{ db?: number }} [options] @returns {string | null} */
 export function redisHGet(key, field, options = {}) {
-  const val = redisCommand(`HGET ${shellQuote(key)} ${shellQuote(field)}`, options);
+  const val = redisCommand(["HGET", key, field], options);
   return val === "" ? null : val;
 }
 
 /** @param {string} key @param {string[]} fields @param {{ db?: number }} [options] @returns {Array<string | null>} */
 export function redisHMGet(key, fields, options = {}) {
   if (fields.length === 0) return [];
-  const dbArgs = options.db == null ? "" : `-n ${options.db} `;
-  const args = fields.map(shellQuote).join(" ");
-  const out = composeExec("redis", `redis-cli ${dbArgs}--raw HMGET ${shellQuote(key)} ${args}`);
+  const dbArgs = options.db == null ? [] : ["-n", String(options.db)];
+  const out = composeExec("redis", ["redis-cli", ...dbArgs, "--raw", "HMGET", key, ...fields]);
   // Preserve empty lines: redis-cli --raw renders HMGET nil slots as blanks.
   const text = out.endsWith("\n") ? out.slice(0, -1) : out;
   return text.split("\n").map((value) => value === "" ? null : value);
@@ -134,23 +128,23 @@ export function redisHGetJson(key, field, options = {}) {
 
 /** @param {string} key @param {Record<string, string>} fields @param {{ db?: number }} [options] @returns {number} */
 export function redisHSet(key, fields, options = {}) {
-  const args = Object.entries(fields).map(([k, v]) => `${shellQuote(k)} ${shellQuote(v)}`).join(" ");
-  return Number(redisCommand(`HSET ${shellQuote(key)} ${args}`, options));
+  const args = Object.entries(fields).flatMap(([field, value]) => [field, value]);
+  return Number(redisCommand(["HSET", key, ...args], options));
 }
 
 /** @param {string} key @param {string[]} fields @param {{ db?: number }} [options] @returns {number} */
 export function redisHDel(key, fields, options = {}) {
-  return Number(redisCommand(`HDEL ${shellQuote(key)} ${fields.map(shellQuote).join(" ")}`, options));
+  return Number(redisCommand(["HDEL", key, ...fields], options));
 }
 
 /** @param {string} key @param {string} field @param {{ db?: number }} [options] @returns {number} */
 export function redisHStrLen(key, field, options = {}) {
-  return Number(redisCommand(`HSTRLEN ${shellQuote(key)} ${shellQuote(field)}`, options));
+  return Number(redisCommand(["HSTRLEN", key, field], options));
 }
 
 /** @param {string} key @param {{ db?: number }} [options] @returns {string[]} */
 export function redisSMembers(key, options = {}) {
-  const out = redisCommand(`SMEMBERS ${shellQuote(key)}`, options);
+  const out = redisCommand(["SMEMBERS", key], options);
   return out ? out.split("\n") : [];
 }
 
@@ -158,69 +152,63 @@ export function redisSMembers(key, options = {}) {
 export function redisSAdd(key, members, options = {}) {
   const values = Array.isArray(members) ? members : [members];
   if (values.length === 0) return 0;
-  return Number(redisCommand(
-    `SADD ${shellQuote(key)} ${values.map(shellQuote).join(" ")}`,
-    options
-  ));
+  return Number(redisCommand(["SADD", key, ...values], options));
 }
 
 /** @param {string} key @param {string|string[]} members @param {{ db?: number }} [options] @returns {number} */
 export function redisSRem(key, members, options = {}) {
   const values = Array.isArray(members) ? members : [members];
   if (values.length === 0) return 0;
-  return Number(redisCommand(
-    `SREM ${shellQuote(key)} ${values.map(shellQuote).join(" ")}`,
-    options
-  ));
+  return Number(redisCommand(["SREM", key, ...values], options));
 }
 
 /** @param {string} key @param {{ db?: number }} [options] @returns {number} */
 export function redisSCard(key, options = {}) {
-  return Number(redisCommand(`SCARD ${shellQuote(key)}`, options));
+  return Number(redisCommand(["SCARD", key], options));
 }
 
 /** @param {string} key @param {number} [start] @param {number} [stop] @param {{ db?: number }} [options] @returns {string[]} */
 export function redisZRange(key, start = 0, stop = -1, options = {}) {
-  const out = redisCommand(`ZRANGE ${shellQuote(key)} ${start} ${stop}`, options);
+  const out = redisCommand(["ZRANGE", key, String(start), String(stop)], options);
   return out ? out.split("\n") : [];
 }
 
 /** @param {string} key @param {string} member @param {{ db?: number }} [options] @returns {string | null} */
 export function redisZScore(key, member, options = {}) {
-  const out = redisCommand(`ZSCORE ${shellQuote(key)} ${shellQuote(member)}`, options);
+  const out = redisCommand(["ZSCORE", key, member], options);
   return out === "" ? null : out;
 }
 
 /** @param {string} key @param {{ db?: number }} [options] @returns {number} */
 export function redisZCard(key, options = {}) {
-  return Number(redisCommand(`ZCARD ${shellQuote(key)}`, options));
+  return Number(redisCommand(["ZCARD", key], options));
 }
 
 /** @param {string} key @param {string} member @param {{ db?: number }} [options] */
 export function redisZRem(key, member, options = {}) {
-  redisCommand(`ZREM ${shellQuote(key)} ${shellQuote(member)}`, options);
+  redisCommand(["ZREM", key, member], options);
 }
 
 /** @param {string} key @param {number} score @param {string} member @param {{ db?: number }} [options] */
 export function redisZAdd(key, score, member, options = {}) {
-  redisCommand(`ZADD ${shellQuote(key)} ${score} ${shellQuote(member)}`, options);
+  redisCommand(["ZADD", key, String(score), member], options);
 }
 
 /** @param {string} pattern @param {{ db?: number }} [options] @returns {string[]} */
 export function redisKeys(pattern, options = {}) {
-  const out = redisCommand(`--raw KEYS ${shellQuote(pattern)}`, options);
+  const out = redisCommand(["--raw", "KEYS", pattern], options);
   return out ? out.split("\n").filter(Boolean) : [];
 }
 
 /** @param {string} key @param {{ db?: number }} [options] @returns {string[]} */
 export function redisHKeys(key, options = {}) {
-  const out = redisCommand(`HKEYS ${shellQuote(key)}`, options);
+  const out = redisCommand(["HKEYS", key], options);
   return out ? out.split("\n") : [];
 }
 
 /** @param {string} stream @param {string} group @param {{ db?: number }} [options] @returns {number} */
 export function redisXPendingCount(stream, group, options = {}) {
-  const out = redisCommand(`XPENDING ${shellQuote(stream)} ${shellQuote(group)}`, options);
+  const out = redisCommand(["XPENDING", stream, group], options);
   if (out === "0") return 0;
   const count = Number(out.split(/\s+/)[0]);
   if (!Number.isInteger(count)) {
@@ -231,7 +219,7 @@ export function redisXPendingCount(stream, group, options = {}) {
 
 /** @param {string} key @param {{ db?: number }} [options] @returns {number} */
 export function redisXLen(key, options = {}) {
-  return Number(redisCommand(`XLEN ${shellQuote(key)}`, options));
+  return Number(redisCommand(["XLEN", key], options));
 }
 
 /**
@@ -243,22 +231,18 @@ export function redisXLen(key, options = {}) {
 export function redisXAdd(key, fields, options = {}) {
   const id = options.id || "*";
   const args = Object.entries(fields)
-    .map(([field, value]) => `${shellQuote(field)} ${shellQuote(String(value))}`)
-    .join(" ");
-  return redisCommand(`XADD ${shellQuote(key)} ${shellQuote(id)} ${args}`, options);
+    .flatMap(([field, value]) => [field, String(value)]);
+  return redisCommand(["XADD", key, id, ...args], options);
 }
 
 /** @param {string} key @param {string} group @param {{ db?: number }} [options] */
 export function redisXGroupCreate(key, group, options = {}) {
-  redisCommand(
-    `XGROUP CREATE ${shellQuote(key)} ${shellQuote(group)} 0 MKSTREAM`,
-    options
-  );
+  redisCommand(["XGROUP", "CREATE", key, group, "0", "MKSTREAM"], options);
 }
 
 /** @param {string} key @param {string} group @param {{ db?: number }} [options] */
 export function redisXGroupDestroy(key, group, options = {}) {
-  redisCommand(`XGROUP DESTROY ${shellQuote(key)} ${shellQuote(group)}`, options);
+  redisCommand(["XGROUP", "DESTROY", key, group], options);
 }
 
 /** @param {string} key @param {string} group @param {string} consumer @param {{ db?: number, count?: number, id?: string }} [options] */
@@ -266,7 +250,7 @@ export function redisXReadGroup(key, group, consumer, options = {}) {
   const count = options.count ?? 1;
   const id = options.id || ">";
   redisCommand(
-    `XREADGROUP GROUP ${shellQuote(group)} ${shellQuote(consumer)} COUNT ${count} STREAMS ${shellQuote(key)} ${shellQuote(id)}`,
+    ["XREADGROUP", "GROUP", group, consumer, "COUNT", String(count), "STREAMS", key, id],
     options
   );
 }
@@ -274,66 +258,70 @@ export function redisXReadGroup(key, group, consumer, options = {}) {
 /** @param {string} key @param {string} group @param {string} consumer @param {string} streamId @param {number} idleMs @param {{ db?: number }} [options] */
 export function redisXClaimIdle(key, group, consumer, streamId, idleMs, options = {}) {
   redisCommand(
-    `XCLAIM ${shellQuote(key)} ${shellQuote(group)} ${shellQuote(consumer)} 0 ${shellQuote(streamId)} IDLE ${idleMs}`,
+    ["XCLAIM", key, group, consumer, "0", streamId, "IDLE", String(idleMs)],
     options
   );
 }
 
 /** @param {string} key @param {{ db?: number }} [options] @returns {string} */
 export function redisXInfoGroups(key, options = {}) {
-  return redisCommand(`XINFO GROUPS ${shellQuote(key)} 2>/dev/null || echo missing`, options);
+  try {
+    return redisCommand(["XINFO", "GROUPS", key], options);
+  } catch {
+    return "missing";
+  }
 }
 
 /** @param {string} key @param {string} [start] @param {string} [stop] @param {{ db?: number, count?: number }} [options] @returns {string} */
 export function redisXRangeRaw(key, start = "-", stop = "+", options = {}) {
-  const countArg = options.count == null ? "" : ` COUNT ${options.count}`;
-  return redisCommand(`XRANGE ${shellQuote(key)} ${shellQuote(start)} ${shellQuote(stop)}${countArg}`, options);
+  const countArgs = options.count == null ? [] : ["COUNT", String(options.count)];
+  return redisCommand(["XRANGE", key, start, stop, ...countArgs], options);
 }
 
 /** @param {string} key @param {{ db?: number }} [options] */
 export function redisDel(key, options = {}) {
-  redisCommand(`DEL ${shellQuote(key)}`, options);
+  redisCommand(["DEL", key], options);
 }
 
 /** @param {string} key @param {string} value @param {number} ttlSeconds @param {{ db?: number }} [options] */
 export function redisSetEx(key, value, ttlSeconds, options = {}) {
-  redisCommand(`SET ${shellQuote(key)} ${shellQuote(value)} EX ${ttlSeconds}`, options);
+  redisCommand(["SET", key, value, "EX", String(ttlSeconds)], options);
 }
 
 /** @param {string} key @param {{ db?: number }} [options] @returns {number} */
 export function redisExpireTime(key, options = {}) {
-  return Number(redisCommand(`EXPIRETIME ${shellQuote(key)}`, options));
+  return Number(redisCommand(["EXPIRETIME", key], options));
 }
 
 /** @param {string} key @param {number} unixSeconds @param {{ db?: number }} [options] @returns {boolean} */
 export function redisExpireAt(key, unixSeconds, options = {}) {
-  return redisCommand(`EXPIREAT ${shellQuote(key)} ${unixSeconds}`, options) === "1";
+  return redisCommand(["EXPIREAT", key, String(unixSeconds)], options) === "1";
 }
 
 /** @param {string} key @param {string} member @param {{ db?: number }} [options] */
 export function redisSIsMember(key, member, options = {}) {
-  return redisCommand(`SISMEMBER ${shellQuote(key)} ${shellQuote(member)}`, options) === "1";
+  return redisCommand(["SISMEMBER", key, member], options) === "1";
 }
 
 /** @param {string} src @param {string} dst @param {{ db?: number, replace?: boolean }} [options] @returns {number} */
 export function redisCopy(src, dst, options = {}) {
-  const replace = options.replace ? " REPLACE" : "";
-  return Number(redisCommand(`COPY ${shellQuote(src)} ${shellQuote(dst)}${replace}`, options));
+  const replace = options.replace ? ["REPLACE"] : [];
+  return Number(redisCommand(["COPY", src, dst, ...replace], options));
 }
 
 export function redisFlushAll() {
-  redisCommand("FLUSHALL");
+  redisCommand(["FLUSHALL"]);
 }
 
 export function redisScriptFlush() {
-  redisCommand("SCRIPT FLUSH");
+  redisCommand(["SCRIPT", "FLUSH"]);
 }
 
 /** @param {string} command @returns {number} */
 export function redisCommandCalls(command) {
   const commandLabel = command.toLowerCase().replaceAll(" ", "|");
   const prefix = `cmdstat_${commandLabel}:`;
-  const line = redisCommand("INFO commandstats")
+  const line = redisCommand(["INFO", "commandstats"])
     .split(/\r?\n/)
     .find((entry) => entry.startsWith(prefix));
   if (line == null) return 0;
@@ -344,15 +332,15 @@ export function redisCommandCalls(command) {
 
 /** @param {string} channel @param {string} message @returns {number} */
 export function redisPublish(channel, message) {
-  return Number(redisCommand(`PUBLISH ${shellQuote(channel)} ${shellQuote(message)}`));
+  return Number(redisCommand(["PUBLISH", channel, message]));
 }
 
 /** @param {string} type */
 export function redisClientKillType(type) {
-  redisCommand(`CLIENT KILL TYPE ${shellQuote(type)}`);
+  redisCommand(["CLIENT", "KILL", "TYPE", type]);
 }
 
 /** @param {number} seconds */
 export function redisDebugSleep(seconds) {
-  redisCommand(`DEBUG SLEEP ${seconds}`);
+  redisCommand(["DEBUG", "SLEEP", String(seconds)]);
 }

--- a/tests/integration/helpers/runtimes.js
+++ b/tests/integration/helpers/runtimes.js
@@ -2,25 +2,30 @@ import { composeProfileUp, composeUp } from "./compose.js";
 import { sh } from "./cli.js";
 
 export function stopD1MultiRuntimes() {
-  sh("COMPOSE_PROFILES=d1-multi docker compose rm -sf d1-runtime-a d1-runtime-b d1-runtime-c", { stdio: "pipe" });
+  sh(["docker", "compose", "rm", "-sf", "d1-runtime-a", "d1-runtime-b", "d1-runtime-c"], {
+    stdio: "pipe",
+    env: { COMPOSE_PROFILES: "d1-multi" },
+  });
 }
 
 export function ensureD1SingleRuntime() {
   // Force-recreate so d1-runtime process-local owner/drain state from a
   // prior multi-runtime test never leaks into a later single-runtime test.
   // Already-clean stacks skip the recreate.
-  const state = sh("docker compose ps --format '{{.Service}} {{.State}}'", { stdio: "pipe" });
+  const state = sh(["docker", "compose", "ps", "--format", "{{.Service}} {{.State}}"], {
+    stdio: "pipe",
+  });
   const multiRunning = /^d1-runtime-[abc] +running/m.test(state);
   const singleHealthy = /^d1-runtime +running/m.test(state);
   if (!multiRunning && singleHealthy) return;
   stopD1MultiRuntimes();
-  sh("docker compose rm -sf d1-runtime", { stdio: "pipe" });
-  return composeUp("--force-recreate --wait d1-runtime", { stdio: "pipe" });
+  sh(["docker", "compose", "rm", "-sf", "d1-runtime"], { stdio: "pipe" });
+  return composeUp(["--force-recreate", "--wait", "d1-runtime"], { stdio: "pipe" });
 }
 
 /** @param {{ ownerLeaseGuardMs?: number }} [options] */
 export function recreateD1MultiRuntimes({ ownerLeaseGuardMs } = {}) {
-  sh("docker compose stop d1-runtime", { stdio: "pipe" });
+  sh(["docker", "compose", "stop", "d1-runtime"], { stdio: "pipe" });
   const opts = {
     stdio: "pipe",
     env: {
@@ -31,23 +36,28 @@ export function recreateD1MultiRuntimes({ ownerLeaseGuardMs } = {}) {
   // The three D1 runtimes intentionally share one localDisk volume in these
   // tests; recreate them one at a time so workerd does not race metadata
   // initialization across fresh processes.
-  composeProfileUp("d1-multi", "--force-recreate --wait d1-runtime-a", opts);
-  composeProfileUp("d1-multi", "--force-recreate --wait d1-runtime-b", opts);
-  return composeProfileUp("d1-multi", "--force-recreate --wait d1-runtime-c", opts);
+  composeProfileUp("d1-multi", ["--force-recreate", "--wait", "d1-runtime-a"], opts);
+  composeProfileUp("d1-multi", ["--force-recreate", "--wait", "d1-runtime-b"], opts);
+  return composeProfileUp("d1-multi", ["--force-recreate", "--wait", "d1-runtime-c"], opts);
 }
 
 export function stopDoMultiRuntimes() {
-  sh("COMPOSE_PROFILES=do-multi docker compose rm -sf do-runtime-a do-runtime-b do-runtime-c", { stdio: "pipe" });
+  sh(["docker", "compose", "rm", "-sf", "do-runtime-a", "do-runtime-b", "do-runtime-c"], {
+    stdio: "pipe",
+    env: { COMPOSE_PROFILES: "do-multi" },
+  });
 }
 
 export function ensureDoSingleRuntime() {
-  const state = sh("docker compose ps --format '{{.Service}} {{.State}}'", { stdio: "pipe" });
+  const state = sh(["docker", "compose", "ps", "--format", "{{.Service}} {{.State}}"], {
+    stdio: "pipe",
+  });
   const multiRunning = /^do-runtime-[abc] +running/m.test(state);
   const singleHealthy = /^do-runtime +running/m.test(state);
   if (!multiRunning && singleHealthy) return;
   stopDoMultiRuntimes();
-  sh("docker compose rm -sf do-runtime", { stdio: "pipe" });
-  return composeUp("--force-recreate --wait do-runtime", { stdio: "pipe" });
+  sh(["docker", "compose", "rm", "-sf", "do-runtime"], { stdio: "pipe" });
+  return composeUp(["--force-recreate", "--wait", "do-runtime"], { stdio: "pipe" });
 }
 
 /**
@@ -59,7 +69,7 @@ export function ensureDoSingleRuntime() {
  * }} [options]
  */
 export function recreateDoMultiRuntimes({ ownerTtlSeconds, ownerLeaseGuardMs, renewStartDelayMs, renewIntervalMs } = {}) {
-  sh("docker compose stop do-runtime", { stdio: "pipe" });
+  sh(["docker", "compose", "stop", "do-runtime"], { stdio: "pipe" });
   const opts = {
     stdio: "pipe",
     env: {
@@ -70,9 +80,9 @@ export function recreateDoMultiRuntimes({ ownerTtlSeconds, ownerLeaseGuardMs, re
       ...(renewIntervalMs == null ? {} : { DO_RENEW_INTERVAL_MS: String(renewIntervalMs) }),
     },
   };
-  composeProfileUp("do-multi", "--force-recreate --wait do-runtime-a", opts);
-  composeProfileUp("do-multi", "--force-recreate --wait do-runtime-b", opts);
-  return composeProfileUp("do-multi", "--force-recreate --wait do-runtime-c", opts);
+  composeProfileUp("do-multi", ["--force-recreate", "--wait", "do-runtime-a"], opts);
+  composeProfileUp("do-multi", ["--force-recreate", "--wait", "do-runtime-b"], opts);
+  return composeProfileUp("do-multi", ["--force-recreate", "--wait", "do-runtime-c"], opts);
 }
 
 /**
@@ -94,21 +104,37 @@ export async function withDoMultiRuntimes(fn, options = {}) {
 }
 
 export function startDoOwnerTask() {
-  composeProfileUp("do-multi", "--force-recreate --wait do-runtime-a", { stdio: "pipe" });
-  const container = sh("COMPOSE_PROFILES=do-multi docker compose ps -q do-runtime-a", { stdio: "pipe" }).trim();
+  composeProfileUp("do-multi", ["--force-recreate", "--wait", "do-runtime-a"], {
+    stdio: "pipe",
+  });
+  const container = sh(["docker", "compose", "ps", "-q", "do-runtime-a"], {
+    stdio: "pipe",
+    env: { COMPOSE_PROFILES: "do-multi" },
+  }).trim();
   const network = sh(
-    `docker inspect -f '{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}' ${container}`,
+    [
+      "docker",
+      "inspect",
+      "-f",
+      "{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}",
+      container,
+    ],
     { stdio: "pipe" }
   ).trim().split("\n")[0];
   // Drop the shared do-runtime-router alias so Envoy's STRICT_DNS pool only
   // resolves the singleton do-runtime; this makes the first WS owner-hint hop
   // deterministically enter through a non-owner task.
-  sh(`docker network disconnect ${network} ${container}`, { stdio: "pipe" });
-  sh(`docker network connect --alias do-runtime-a ${network} ${container}`, { stdio: "pipe" });
+  sh(["docker", "network", "disconnect", network, container], { stdio: "pipe" });
+  sh(["docker", "network", "connect", "--alias", "do-runtime-a", network, container], {
+    stdio: "pipe",
+  });
 }
 
 export function stopDoOwnerTask() {
-  return sh("COMPOSE_PROFILES=do-multi docker compose rm -sf do-runtime-a", { stdio: "pipe" });
+  return sh(["docker", "compose", "rm", "-sf", "do-runtime-a"], {
+    stdio: "pipe",
+    env: { COMPOSE_PROFILES: "do-multi" },
+  });
 }
 
 /** @param {() => Promise<unknown>} fn */

--- a/tests/integration/helpers/shell-quote.js
+++ b/tests/integration/helpers/shell-quote.js
@@ -1,4 +1,0 @@
-/** @param {string} value */
-export function shellQuote(value) {
-  return `'${String(value).replaceAll("'", "'\\''")}'`;
-}

--- a/tests/integration/helpers/stack.js
+++ b/tests/integration/helpers/stack.js
@@ -60,7 +60,7 @@ function prepareDirectIntegrationArtifacts() {
 export async function ensureStackUp() {
   if (stackReady) return;
   prepareDirectIntegrationArtifacts();
-  composeUp("--wait test-probe", { stdio: "pipe" });
+  composeUp(["--wait", "test-probe"], { stdio: "pipe" });
   if (process.env.WDL_INTEGRATION_SLOT_PREPPED === "1") {
     ensureD1SingleRuntime();
     ensureDoSingleRuntime();
@@ -69,7 +69,8 @@ export async function ensureStackUp() {
     stackReady = true;
     return;
   }
-  const state = sh("docker compose ps --format '{{.Service}} {{.State}}'").trim();
+  const state = sh(["docker", "compose", "ps", "--format", "{{.Service}} {{.State}}"])
+    .trim();
   const required = [
     "test-probe", "redis", "s3mock", "redis-proxy-user", "redis-proxy-system", "redis-proxy-do",
     "d1-runtime", "do-runtime", "user-runtime", "system-runtime", "gateway", "scheduler",
@@ -77,28 +78,28 @@ export async function ensureStackUp() {
   ];
   const missing = required.filter((s) => !new RegExp(`^${RegExp.escape(s)} running`, "m").test(state));
   if (missing.length) {
-    composeUp("", { stdio: "inherit" });
+    composeUp([], { stdio: "inherit" });
   } else {
     // Sequential, dep-order restart: parallel restart lets gateway's
     // workerd getaddrinfo("user-runtime") before Docker DNS updates,
     // which then caches the failure for the process lifetime.
-    sh("docker compose restart redis-proxy-user", { stdio: "pipe" });
-    composeUp("--wait redis-proxy-user", { stdio: "pipe" });
-    sh("docker compose restart redis-proxy-system", { stdio: "pipe" });
-    composeUp("--wait redis-proxy-system", { stdio: "pipe" });
-    sh("docker compose restart d1-runtime", { stdio: "pipe" });
-    composeUp("--wait d1-runtime", { stdio: "pipe" });
-    sh("docker compose restart redis-proxy-do", { stdio: "pipe" });
-    composeUp("--wait redis-proxy-do", { stdio: "pipe" });
-    sh("docker compose restart do-runtime", { stdio: "pipe" });
-    composeUp("--wait do-runtime", { stdio: "pipe" });
-    sh("docker compose restart user-runtime", { stdio: "pipe" });
-    composeUp("--wait user-runtime", { stdio: "pipe" });
-    sh("docker compose restart system-runtime", { stdio: "pipe" });
-    composeUp("--wait system-runtime", { stdio: "pipe" });
-    sh("docker compose restart gateway", { stdio: "pipe" });
-    composeUp("--wait gateway", { stdio: "pipe" });
-    composeUp("--force-recreate --wait scheduler", { stdio: "pipe" });
+    sh(["docker", "compose", "restart", "redis-proxy-user"], { stdio: "pipe" });
+    composeUp(["--wait", "redis-proxy-user"], { stdio: "pipe" });
+    sh(["docker", "compose", "restart", "redis-proxy-system"], { stdio: "pipe" });
+    composeUp(["--wait", "redis-proxy-system"], { stdio: "pipe" });
+    sh(["docker", "compose", "restart", "d1-runtime"], { stdio: "pipe" });
+    composeUp(["--wait", "d1-runtime"], { stdio: "pipe" });
+    sh(["docker", "compose", "restart", "redis-proxy-do"], { stdio: "pipe" });
+    composeUp(["--wait", "redis-proxy-do"], { stdio: "pipe" });
+    sh(["docker", "compose", "restart", "do-runtime"], { stdio: "pipe" });
+    composeUp(["--wait", "do-runtime"], { stdio: "pipe" });
+    sh(["docker", "compose", "restart", "user-runtime"], { stdio: "pipe" });
+    composeUp(["--wait", "user-runtime"], { stdio: "pipe" });
+    sh(["docker", "compose", "restart", "system-runtime"], { stdio: "pipe" });
+    composeUp(["--wait", "system-runtime"], { stdio: "pipe" });
+    sh(["docker", "compose", "restart", "gateway"], { stdio: "pipe" });
+    composeUp(["--wait", "gateway"], { stdio: "pipe" });
+    composeUp(["--force-recreate", "--wait", "scheduler"], { stdio: "pipe" });
   }
   ensureD1SingleRuntime();
   ensureDoSingleRuntime();

--- a/tests/integration/helpers/structured-logs.js
+++ b/tests/integration/helpers/structured-logs.js
@@ -1,6 +1,5 @@
 import { sh } from "./cli.js";
 import { parseJsonText } from "./json-payload.js";
-import { shellQuote } from "./shell-quote.js";
 
 /**
  * @param {string} service
@@ -10,9 +9,7 @@ import { shellQuote } from "./shell-quote.js";
  */
 export function structuredServiceLogEvents(service, event, options = {}) {
   const tail = options.tail ?? 500;
-  const raw = sh(
-    `docker compose logs --no-color --tail=${tail} ${shellQuote(service)}`
-  );
+  const raw = sh(["docker", "compose", "logs", "--no-color", `--tail=${tail}`, service]);
   /** @type {Record<string, unknown>[]} */
   const events = [];
   for (const line of raw.split("\n")) {

--- a/tests/integration/log-tail.test.js
+++ b/tests/integration/log-tail.test.js
@@ -773,9 +773,12 @@ test("wdl tail: resume past the MAXLEN trim surfaces tail_warning{resume_point_t
   // through gatewayFetch 600× would be ~30s and brittle).
   for (let i = 0; i < 12; i++) {
     redisCommand(
-      `EVAL ${JSON.stringify(
-        `for i=1,50 do redis.call('XADD', KEYS[1], 'MAXLEN', '~', '500', '*', 'json', '{}') end return 1`
-      )} 1 ${JSON.stringify(`logs:${ns}:tail-target:s`)}`,
+      [
+        "EVAL",
+        "for i=1,50 do redis.call('XADD', KEYS[1], 'MAXLEN', '~', '500', '*', 'json', '{}') end return 1",
+        "1",
+        `logs:${ns}:tail-target:s`,
+      ],
       { db: 1 }
     );
   }

--- a/tests/integration/manual/websocket-hang-repro.manual.mjs
+++ b/tests/integration/manual/websocket-hang-repro.manual.mjs
@@ -13,7 +13,7 @@ import assert from "node:assert/strict";
 import {
   composeStart,
   composeStop,
-  composeUpNoBuildArgs,
+  composeUp,
   deployAndPromote,
   ensureStackUp,
   encodeClientTextFrame,
@@ -79,15 +79,7 @@ test(
       if (backendStopped) {
         try {
           composeStart("user-runtime");
-          sh([
-            "docker",
-            "compose",
-            "up",
-            "-d",
-            ...composeUpNoBuildArgs(),
-            "--wait",
-            "user-runtime",
-          ]);
+          composeUp(["--wait", "user-runtime"]);
         } catch (err) {
           console.error("failed to restart user-runtime:", err);
         }

--- a/tests/integration/manual/websocket-hang-repro.manual.mjs
+++ b/tests/integration/manual/websocket-hang-repro.manual.mjs
@@ -13,7 +13,7 @@ import assert from "node:assert/strict";
 import {
   composeStart,
   composeStop,
-  composeUpNoBuildFlag,
+  composeUpNoBuildArgs,
   deployAndPromote,
   ensureStackUp,
   encodeClientTextFrame,
@@ -79,7 +79,15 @@ test(
       if (backendStopped) {
         try {
           composeStart("user-runtime");
-          sh(`docker compose up -d${composeUpNoBuildFlag()} --wait user-runtime`);
+          sh([
+            "docker",
+            "compose",
+            "up",
+            "-d",
+            ...composeUpNoBuildArgs(),
+            "--wait",
+            "user-runtime",
+          ]);
         } catch (err) {
           console.error("failed to restart user-runtime:", err);
         }
@@ -89,7 +97,7 @@ test(
     // workerd's hang error is from server.c++ stderr, not our structured
     // logger, so it may not carry our request id — search both.
     const gatewayLogs = sh(
-      `docker compose logs --no-color --since=${logSince} gateway`,
+      ["docker", "compose", "logs", "--no-color", `--since=${logSince}`, "gateway"],
       { stdio: "pipe" }
     );
     const idLogs = gatewayLogs

--- a/tests/integration/redis-conformance.test.js
+++ b/tests/integration/redis-conformance.test.js
@@ -74,11 +74,11 @@ for (const conformanceCase of redisConformanceCases) {
 
 test("real redis conformance: HSET clears an existing hash field TTL", () => {
   const key = uniqueNs("redisconf-hset-ttl");
-  redisCommand(`HSETEX ${key} EX 60 FIELDS 1 value old`);
-  assert.ok(Number(redisCommand(`HPTTL ${key} FIELDS 1 value`)) > 0);
+  redisCommand(["HSETEX", key, "EX", "60", "FIELDS", "1", "value", "old"]);
+  assert.ok(Number(redisCommand(["HPTTL", key, "FIELDS", "1", "value"])) > 0);
 
   redisHSet(key, { value: "new" });
 
   assert.equal(redisHGet(key, "value"), "new");
-  assert.equal(Number(redisCommand(`HPTTL ${key} FIELDS 1 value`)), -1);
+  assert.equal(Number(redisCommand(["HPTTL", key, "FIELDS", "1", "value"])), -1);
 });

--- a/tests/integration/scheduler-shutdown-drain.test.js
+++ b/tests/integration/scheduler-shutdown-drain.test.js
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import {
   adminPost,
   assertStatus,
-  composeUpNoBuildFlag,
+  composeUpNoBuildArgs,
   deployAndPromote,
   gatewayWorkerId,
   runtimeInternalPost,
@@ -25,7 +25,7 @@ setupIntegrationSuite({
   async afterStackUp() {
     // Drop stale registry/PEL from prior suites (same hygiene as queues-delivery.test.js).
     redisFlushAll();
-    sh("docker compose restart scheduler", { stdio: "pipe" });
+    sh(["docker", "compose", "restart", "scheduler"], { stdio: "pipe" });
     await waitForScheduler();
   },
 });
@@ -97,7 +97,7 @@ test("scheduler: SIGTERM mid-dispatch drains in-flight queue handler before exit
 
   // -t 30s ≥ scheduler drain (25s) ≥ consumer latency (2s); docker default
   // 10s would SIGKILL before drain could finish in pathological cases.
-  sh("docker compose stop -t 30 scheduler", { stdio: "pipe" });
+  sh(["docker", "compose", "stop", "-t", "30", "scheduler"], { stdio: "pipe" });
 
   try {
     const pelCountAfter = redisXPendingCount(streamKey, "wdl-scheduler", { db: 1 });
@@ -116,6 +116,8 @@ test("scheduler: SIGTERM mid-dispatch drains in-flight queue handler before exit
   } finally {
     // Must restore even if asserts threw — otherwise queues/crons/s3-cleanup
     // suites cascade-fail. --wait blocks on the healthcheck, not on Redis.
-    sh(`docker compose up -d${composeUpNoBuildFlag()} --wait scheduler`, { stdio: "pipe" });
+    sh(["docker", "compose", "up", "-d", ...composeUpNoBuildArgs(), "--wait", "scheduler"], {
+      stdio: "pipe",
+    });
   }
 });

--- a/tests/integration/scheduler-shutdown-drain.test.js
+++ b/tests/integration/scheduler-shutdown-drain.test.js
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import {
   adminPost,
   assertStatus,
-  composeUpNoBuildArgs,
+  composeUp,
   deployAndPromote,
   gatewayWorkerId,
   runtimeInternalPost,
@@ -116,8 +116,6 @@ test("scheduler: SIGTERM mid-dispatch drains in-flight queue handler before exit
   } finally {
     // Must restore even if asserts threw — otherwise queues/crons/s3-cleanup
     // suites cascade-fail. --wait blocks on the healthcheck, not on Redis.
-    sh(["docker", "compose", "up", "-d", ...composeUpNoBuildArgs(), "--wait", "scheduler"], {
-      stdio: "pipe",
-    });
+    composeUp(["--wait", "scheduler"], { stdio: "pipe" });
   }
 });

--- a/tests/unit/auth-lib.test.js
+++ b/tests/unit/auth-lib.test.js
@@ -19,7 +19,6 @@ const {
   DELEGATED_ISSUE_TEMPLATES,
   MAX_TOKEN_HEADER_BYTES,
   assertTenantNs,
-  createDelegatedIssueTemplateMap,
   isValidTenantNs,
   evaluateAccess,
   validateIssueInput,
@@ -552,83 +551,58 @@ test("validateIssueInput: bogus boundNsKind triggers invalid_role_config (defaul
 });
 
 test("delegated issue templates are code-defined and render labels", () => {
-  const templates = createDelegatedIssueTemplateMap();
-  const chat = templates.get("wdl-chat-ns-pool");
-  const cli = templates.get("wdl-cli-integration");
-  assert.ok(chat);
-  assert.ok(cli);
+  const chat = resolveDelegatedIssueTemplate("wdl-chat-ns-pool");
+  const cli = resolveDelegatedIssueTemplate("wdl-cli-integration");
   assert.deepEqual(
     DELEGATED_ISSUE_TEMPLATES.map((/** @type {{ id: string }} */ t) => t.id),
     ["wdl-chat-ns-pool", "wdl-cli-integration"]
   );
   assert.equal(chat.version, "1");
-  assert.equal(chat.disabled, false);
   assert.equal(renderDelegatedIssueLabel(chat, "tmp-00112233"), "workshop-pool tmp-00112233");
-  assert.equal(resolveDelegatedIssueTemplate("wdl-chat-ns-pool", templates), chat);
   assert.equal(cli.version, "1");
-  assert.equal(cli.disabled, false);
   assert.equal(cli.ttlSeconds, 60 * 60);
   assert.equal(cli.activeQuota, 50);
   assert.deepEqual(cli.nsGenerator, { prefix: "cli-it-", randomHexBytes: 4 });
   assert.equal(renderDelegatedIssueLabel(cli, "cli-it-00112233"), "cli live integration cli-it-00112233");
-  assert.equal(resolveDelegatedIssueTemplate("wdl-cli-integration", templates), cli);
 });
 
-test("delegated issue template resolver rejects missing and disabled templates consistently", () => {
-  const disabled = createDelegatedIssueTemplateMap([{
-    id: "disabled-template",
-    targetKind: "ns",
-    nsGenerator: { prefix: "tmp-", randomHexBytes: 4 },
-    labelTemplate: "pool {ns}",
-    ttlSeconds: 60,
-    activeQuota: 1,
-    disabled: true,
-  }]);
+test("delegated issue template resolver rejects missing templates", () => {
   assert.throws(
-    () => resolveDelegatedIssueTemplate("missing-template", disabled),
+    () => resolveDelegatedIssueTemplate("missing-template"),
     (err) => err instanceof AuthPolicyError &&
       /** @type {any} */ (err).status === 400 &&
       /** @type {any} */ (err).reason === "invalid_template"
   );
-  assert.throws(
-    () => resolveDelegatedIssueTemplate("disabled-template", disabled),
-    (err) => err instanceof AuthPolicyError &&
-      /** @type {any} */ (err).status === 400 &&
-      /** @type {any} */ (err).reason === "template_disabled"
-  );
 });
 
-test("delegated issue template code-shape failures are server misconfiguration", () => {
-  for (const templates of [
-    null,
-    "",
-    {},
-    [],
-    [{ id: "Bad", targetKind: "ns" }],
-    [{
-      id: "bad-target",
-      targetKind: "token-issuer",
-      nsGenerator: { prefix: "tmp-", randomHexBytes: 4 },
-      labelTemplate: "pool {ns}",
-      ttlSeconds: 60,
-      activeQuota: 1,
-    }],
-    [{
-      id: "long-label",
-      targetKind: "ns",
-      nsGenerator: { prefix: "tmp-", randomHexBytes: 4 },
-      labelTemplate: "{ns} ".repeat(12),
-      ttlSeconds: 60,
-      activeQuota: 1,
-    }],
-  ]) {
-    assert.throws(
-      () => createDelegatedIssueTemplateMap(templates),
-      (err) => err instanceof AuthPolicyError &&
-        /** @type {any} */ (err).status === 503 &&
-        /** @type {any} */ (err).reason === "delegated_issue_misconfigured",
-      `expected config failure for ${String(templates)}`
-    );
+test("delegated issue template constants satisfy their static contract", () => {
+  assert.ok(Object.isFrozen(DELEGATED_ISSUE_TEMPLATES));
+  assert.ok(DELEGATED_ISSUE_TEMPLATES.length > 0);
+  const ids = new Set();
+  for (const template of DELEGATED_ISSUE_TEMPLATES) {
+    assert.ok(Object.isFrozen(template), `${template.id} must be frozen`);
+    assert.ok(Object.isFrozen(template.nsGenerator), `${template.id} generator must be frozen`);
+    assert.match(template.id, /^[a-z][a-z0-9-]{0,63}$/);
+    assert.ok(!ids.has(template.id), `duplicate template ${template.id}`);
+    ids.add(template.id);
+
+    assert.ok(Object.hasOwn(ROLES, template.targetKind), `${template.id} target role exists`);
+    assert.equal(ROLES[template.targetKind].boundNsKind, "tenant");
+
+    const { prefix, randomHexBytes } = template.nsGenerator;
+    assert.ok(prefix.length > 0, `${template.id} generator prefix must be non-empty`);
+    assert.ok(Number.isInteger(randomHexBytes) && randomHexBytes >= 1 && randomHexBytes <= 16);
+    const sampleNs = prefix + "0".repeat(randomHexBytes * 2);
+    assert.ok(isValidTenantNs(sampleNs), `${template.id} must generate valid tenant namespaces`);
+
+    assert.ok(template.labelTemplate.includes("{ns}"));
+    assert.ok(template.labelTemplate.length <= 128);
+    assert.ok(renderDelegatedIssueLabel(template, sampleNs).length <= 128);
+    assert.ok(Number.isInteger(template.ttlSeconds));
+    assert.ok(template.ttlSeconds >= 1 && template.ttlSeconds <= 30 * 24 * 60 * 60);
+    assert.ok(Number.isInteger(template.activeQuota));
+    assert.ok(template.activeQuota >= 1 && template.activeQuota <= 10_000);
+    assert.match(template.version, /^[A-Za-z0-9._:-]{1,64}$/);
   }
 });
 

--- a/tests/unit/control-delete-handler.test.js
+++ b/tests/unit/control-delete-handler.test.js
@@ -642,9 +642,6 @@ function resetVersionListHandlerState() {
     async get() {
       throw new Error("versions GET must not read next_version");
     },
-    async hExistsMany() {
-      throw new Error("versions GET must not scan historical bundle keys");
-    },
   };
   return installControlHandlerState("__versionDeleteHandlerState", {
     cleanupIntents: [],

--- a/tests/unit/control-reload-handler.test.js
+++ b/tests/unit/control-reload-handler.test.js
@@ -130,3 +130,27 @@ test("reload handler preserves publish failure status with camelCase duration", 
     },
   });
 });
+
+test("reload handler does not invent publish results when declaration repair fails", async () => {
+  resetReloadHandlerState({
+    ok: false,
+    declarations: {
+      ok: false,
+      error: "declared host repair failed",
+      duration_ms: 4,
+    },
+  });
+
+  const response = await handle({ requestId: "rid-reload-repair-fail" });
+
+  await assertJsonResponse(response, 502, {
+    reload: {
+      ok: false,
+      declarations: {
+        ok: false,
+        durationMs: 4,
+        error: "declared host repair failed",
+      },
+    },
+  });
+});

--- a/tests/unit/control-shared.test.js
+++ b/tests/unit/control-shared.test.js
@@ -959,28 +959,12 @@ test("readJsonBody: invalid JSON returns machine-code error plus message", async
   });
 });
 
-test("readJsonBody: empty body is invalid unless explicitly allowed", async () => {
+test("readJsonBody: empty body is invalid", async () => {
   const rejected = await readJsonBody(new Request("http://x", {
     method: "POST",
   }));
   assert.ok(rejected.response);
   assert.deepEqual(await rejected.response.json(), {
-    error: "invalid_json",
-    message: "Body must be valid JSON",
-  });
-
-  const allowed = await readJsonBody(new Request("http://x", {
-    method: "POST",
-  }), { allowEmpty: true });
-  assert.deepEqual(allowed, { body: {} });
-
-  const malformedWithAllowEmpty = await readJsonBody(new Request("http://x", {
-    method: "POST",
-    body: "{",
-  }), { allowEmpty: true });
-  assert.ok(malformedWithAllowEmpty.response);
-  assert.equal(malformedWithAllowEmpty.response.status, 400);
-  assert.deepEqual(await malformedWithAllowEmpty.response.json(), {
     error: "invalid_json",
     message: "Body must be valid JSON",
   });

--- a/tests/unit/do-runtime-protocol.test.js
+++ b/tests/unit/do-runtime-protocol.test.js
@@ -525,6 +525,20 @@ test("local actor requests reject legacy JSON metadata", async () => {
   );
 });
 
+test("local actor envelope decode errors retain local protocol wording", async () => {
+  await assert.rejects(
+    readLocalActorInvokeRequest(new Request("https://do-runtime.internal/invoke", {
+      method: "POST",
+      headers: { "x-wdl-do-local-envelope": "binary" },
+      body: new Uint8Array([0, 0, 0]),
+    })),
+    (err) => err instanceof DoRuntimeError &&
+      err.status === 400 &&
+      err.code === "invalid_request" &&
+      err.message === "local actor envelope is truncated"
+  );
+});
+
 test("normalizes do websocket connect request from internal headers", () => {
   const request = new Request("http://do-runtime/internal/do/connect", {
     method: "GET",

--- a/tests/unit/fake-redis.test.js
+++ b/tests/unit/fake-redis.test.js
@@ -138,18 +138,11 @@ test("fake redis mirrors combined hash and string snapshots", async () => {
       hash: {},
       value: null,
     });
-    redis.sets.set("refs:a", new Set(["worker", "version"]));
-    assert.deepEqual(await session.hGetAllGetSMembers("hash:a", "alias:a", "refs:a"), {
-      hash: { one: "1" },
-      value: "target-a",
-      members: ["worker", "version"],
-    });
   });
   assert.deepEqual(redis.commands, [
     ["hGetAllAndGet", "hash:a", "alias:a"],
     ["sMembersAndHGetAll", "members:a", "hash:a"],
     ["hGetAllAndGet", "hash:missing", "alias:missing"],
-    ["hGetAllGetSMembers", "hash:a", "alias:a", "refs:a"],
   ]);
 
   const rawRedis = createFakeRedis(undefined, { encodeGet: true });

--- a/tests/unit/gateway-dispatch.test.js
+++ b/tests/unit/gateway-dispatch.test.js
@@ -466,25 +466,3 @@ test("resolveGatewayDispatch routes allowed __system__ pattern hits to system ru
     version: "v2",
   });
 });
-
-test("resolveGatewayDispatch rejects disallowed reserved pattern hits", async () => {
-  const ctx = dispatch("https://custom.workers.example/platform", {
-    knownPatternHosts: new Set(["custom.workers.example"]),
-    patterns: [{
-      slot: "/platform",
-      kind: "exact",
-      value: "/platform",
-      ns: "__platform__",
-      worker: "p",
-      version: "v1",
-    }],
-  });
-
-  assert.deepEqual(await ctx.result, {
-    kind: "not_found",
-    route: "worker_fetch_pattern",
-    namespace: "__platform__",
-    worker: "p",
-    version: "v1",
-  });
-});

--- a/tests/unit/gateway-lib.test.js
+++ b/tests/unit/gateway-lib.test.js
@@ -2,7 +2,6 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   deleteGatewayInternalHeaders,
-  escapeRegex,
   classifyHost,
   isPatternInvalidationKey,
   normalizeRequestHost,
@@ -39,14 +38,6 @@ test("deleteGatewayInternalHeaders removes fixed and prefixed private headers", 
 function matchPattern(sorted, pathname, search = "") {
   return matchPatternWithStats(sorted, pathname, search).entry;
 }
-
-test("escapeRegex produces regex-safe literals", () => {
-  for (const value of ["a.b", "a*b+c?", "[a](b){c}|d", "^start$", "back\\slash", "foo-bar", "a b"]) {
-    const re = new RegExp(`^${escapeRegex(value)}$`);
-    assert.equal(re.test(value), true, value);
-    assert.equal(re.test(`${value}x`), false, value);
-  }
-});
 
 test("classifyHost: subdomain match", () => {
   const r = classifyHost("demo.workers.local", "workers.local", NS_PATTERN);

--- a/tests/unit/gateway-runtime.test.js
+++ b/tests/unit/gateway-runtime.test.js
@@ -50,10 +50,24 @@ export function decodePatternProjection(raw) {
 `);
 const gatewayLibOwnerUrl = repositoryFileUrl("gateway/lib.js");
 const gatewayLibUrl = moduleDataUrl(`
-export { normalizeRequestHost } from ${JSON.stringify(gatewayLibOwnerUrl)};
+export {
+  GatewayRoutingUnavailableError,
+  normalizeRequestHost,
+} from ${JSON.stringify(gatewayLibOwnerUrl)};
 export function isPatternInvalidationKey() { return true; }
 export function sortPatterns(entries) { return { sorted: entries, errors: [] }; }
 `);
+const webSocketLifecycleSrc = applyModuleReplacements(
+  readRepositoryFile("gateway/websocket-lifecycle.js"),
+  [
+    [/from "shared-redis";/, `from ${JSON.stringify(redisUrl)};`],
+    [/from "shared-observability";/, `from ${JSON.stringify(OBSERVABILITY_NOOP_URL)};`],
+    [/from "shared-ns-pattern";/, `from ${JSON.stringify(nsPatternUrl)};`],
+    [/from "shared-worker-contract";/, `from ${JSON.stringify(repositoryFileUrl("shared/worker-contract.js"))};`],
+    [/from "gateway-lib";/, `from ${JSON.stringify(gatewayLibUrl)};`],
+  ]
+);
+const webSocketLifecycleUrl = moduleDataUrl(webSocketLifecycleSrc);
 
 const src = applyModuleReplacements(readRepositoryFile("gateway/runtime.js"), [
   [/from "shared-redis";/, `from ${JSON.stringify(redisUrl)};`],
@@ -62,6 +76,7 @@ const src = applyModuleReplacements(readRepositoryFile("gateway/runtime.js"), [
   [/from "shared-ns-pattern";/, `from ${JSON.stringify(nsPatternUrl)};`],
   [/from "shared-worker-contract";/, `from ${JSON.stringify(repositoryFileUrl("shared/worker-contract.js"))};`],
   [/from "gateway-lib";/, `from ${JSON.stringify(gatewayLibUrl)};`],
+  [/from "gateway-websocket-lifecycle";/, `from ${JSON.stringify(webSocketLifecycleUrl)};`],
 ]);
 
 let runtimeLoadSerial = 0;

--- a/tests/unit/integration-cli-helper.test.js
+++ b/tests/unit/integration-cli-helper.test.js
@@ -1,31 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { integrationChildEnv, parseIntegrationCommandForTest } from "../integration/helpers/cli.js";
-
-const NODE = JSON.stringify(process.execPath);
-
-test("integration sh parses env assignments and quoted arguments without shell execution", () => {
-  const parsed = parseIntegrationCommandForTest(
-    `TEST_SH_VALUE=inline ${NODE} -e 'process.stdout.write(process.env.TEST_SH_VALUE + ":" + process.argv[1])' 'hello world'`
-  );
-  assert.deepEqual(parsed.env, { TEST_SH_VALUE: "inline" });
-  assert.deepEqual(parsed.argv, [
-    process.execPath,
-    "-e",
-    "process.stdout.write(process.env.TEST_SH_VALUE + \":\" + process.argv[1])",
-    "hello world",
-  ]);
-});
-
-test("integration sh does not treat quoted assignment-looking tokens as env", () => {
-  const parsed = parseIntegrationCommandForTest(
-    `'TEST_SH_VALUE=inline' ${NODE} -e 'process.stdout.write(process.env.TEST_SH_VALUE || "")'`
-  );
-  assert.deepEqual(parsed.env, {});
-  assert.equal(parsed.argv[0], "TEST_SH_VALUE=inline");
-  assert.equal(parsed.quoted[0], true);
-});
+import { integrationChildEnv, sh } from "../integration/helpers/cli.js";
 
 test("integration sh does not leak node:test worker env into child processes", () => {
   const env = integrationChildEnv(
@@ -37,83 +13,17 @@ test("integration sh does not leak node:test worker env into child processes", (
   assert.equal(env.TEST_VALUE, "override");
 });
 
-test("integration sh supports the explicit missing fallback used by Redis probes", () => {
-  const parsed = parseIntegrationCommandForTest(`${NODE} -e 'process.exit(3)' 2>/dev/null || echo missing`);
-  assert.deepEqual(parsed.argv, [process.execPath, "-e", "process.exit(3)"]);
-  assert.equal(parsed.fallbackOutput, "missing\n");
-});
-
-test("integration sh rejects unsupported shell operators after parsing", () => {
-  assert.throws(
-    () => parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write("first")' && ${NODE} -e 'process.stdout.write("second")'`),
-    /unsupported integration shell syntax: &&/
+test("integration sh forwards argv and env without shell parsing", () => {
+  const output = sh(
+    [
+      process.execPath,
+      "-e",
+      "process.stdout.write(process.env.TEST_SH_VALUE + ':' + JSON.stringify(process.argv.slice(1)))",
+      "hello world",
+      "",
+      "left && right",
+    ],
+    { env: { TEST_SH_VALUE: "inline" } }
   );
-});
-
-test("integration sh rejects unsupported ';' operator after parsing", () => {
-  assert.throws(
-    () => parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write("first")' ; ${NODE} -e 'process.stdout.write("second")'`),
-    /unsupported integration shell syntax: ;/
-  );
-});
-
-test("integration sh rejects unsupported '|' operator after parsing", () => {
-  assert.throws(
-    () => parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write("first")' | ${NODE} -e 'process.stdout.write("second")'`),
-    /unsupported integration shell syntax: \|/
-  );
-});
-
-test("integration sh rejects unsupported shell redirection after parsing", () => {
-  assert.throws(
-    () => parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write("hidden")' >/dev/null`),
-    /unsupported integration shell redirection: >\/dev\/null/
-  );
-  assert.throws(
-    () => parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write("hidden")' >`),
-    /unsupported integration shell redirection: >/
-  );
-});
-
-test("integration sh rejects other unsupported shell redirection operators, including standalone stderr redirection", () => {
-  assert.throws(
-    () => parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write("hidden")' >>/dev/null`),
-    /unsupported integration shell redirection: >>\/dev\/null/
-  );
-  assert.throws(
-    () => parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write("hidden")' <<EOF`),
-    /unsupported integration shell redirection: <<EOF/
-  );
-  assert.throws(
-    () => parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write("hidden")' </dev/null`),
-    /unsupported integration shell redirection: <\/dev\/null/
-  );
-  // `2>/dev/null` is only modeled inside the exact `2>/dev/null || echo missing`
-  // fallback shape above; standalone stderr redirection remains unsupported.
-  assert.throws(
-    () => parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write("hidden")' 2>/dev/null`),
-    /unsupported integration shell redirection: 2>\/dev\/null/
-  );
-});
-
-test("integration sh keeps quoted operator-looking arguments as argv", () => {
-  const parsed = parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write(process.argv[1])' 'left && right'`);
-  assert.equal(parsed.argv.at(-1), "left && right");
-  assert.equal(parsed.quoted.at(-1), true);
-});
-
-test("integration sh preserves empty quoted arguments", () => {
-  const parsed = parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write(JSON.stringify(process.argv.slice(1)))' x '' y`);
-  assert.deepEqual(parsed.argv.slice(-3), ["x", "", "y"]);
-});
-
-test("integration sh allows quoted operator-looking scalar values", () => {
-  const parsed = parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write(process.argv.slice(1).join(","))' '<html>' '|' '2>x'`);
-  assert.deepEqual(parsed.argv.slice(-3), ["<html>", "|", "2>x"]);
-  assert.deepEqual(parsed.quoted.slice(-3), [true, true, true]);
-});
-
-test("integration sh preserves literal backslashes in double-quoted arguments", () => {
-  const parsed = parseIntegrationCommandForTest(`${NODE} -e 'process.stdout.write(process.argv[1])' "a\\nb"`);
-  assert.equal(parsed.argv.at(-1), String.raw`a\nb`);
+  assert.equal(output, 'inline:["hello world","","left && right"]');
 });

--- a/tests/unit/integration-environment.test.js
+++ b/tests/unit/integration-environment.test.js
@@ -24,7 +24,7 @@ const composeHelper = await importRepositoryModule(
       "scripts/integration-environment.js"
     ),
     "./env.js": moduleDataUrl('export const ROOT = ".";'),
-    "./cli.js": moduleDataUrl("export function sh(command) { return command; }"),
+    "./cli.js": moduleDataUrl("export function sh(argv, opts = {}) { return { argv, opts }; }"),
   })
 );
 
@@ -35,23 +35,29 @@ test("compose no-build flag follows the integration environment", () => {
 
 test("compose helpers consume the shared preflight no-build flag", async () => {
   await withMockedProperty(process.env, "WDL_INTEGRATION_NO_BUILD", "1", () => {
-    assert.equal(
-      composeHelper.composeUp("--wait gateway"),
-      "docker compose up -d --no-build --wait gateway"
+    assert.deepEqual(
+      composeHelper.composeUp(["--wait", "gateway"]),
+      { argv: ["docker", "compose", "up", "-d", "--no-build", "--wait", "gateway"], opts: {} }
     );
-    assert.equal(
-      composeHelper.composeProfileUp("d1-multi", "--wait d1-runtime-a"),
-      "COMPOSE_PROFILES=d1-multi docker compose up -d --no-build --wait d1-runtime-a"
+    assert.deepEqual(
+      composeHelper.composeProfileUp("d1-multi", ["--wait", "d1-runtime-a"]),
+      {
+        argv: ["docker", "compose", "up", "-d", "--no-build", "--wait", "d1-runtime-a"],
+        opts: { env: { COMPOSE_PROFILES: "d1-multi" } },
+      }
     );
   });
   await withMockedProperty(process.env, "WDL_INTEGRATION_NO_BUILD", "0", () => {
-    assert.equal(
-      composeHelper.composeUp("--wait gateway"),
-      "docker compose up -d --wait gateway"
+    assert.deepEqual(
+      composeHelper.composeUp(["--wait", "gateway"]),
+      { argv: ["docker", "compose", "up", "-d", "--wait", "gateway"], opts: {} }
     );
-    assert.equal(
-      composeHelper.composeProfileUp("d1-multi", "--wait d1-runtime-a"),
-      "COMPOSE_PROFILES=d1-multi docker compose up -d --wait d1-runtime-a"
+    assert.deepEqual(
+      composeHelper.composeProfileUp("d1-multi", ["--wait", "d1-runtime-a"]),
+      {
+        argv: ["docker", "compose", "up", "-d", "--wait", "d1-runtime-a"],
+        opts: { env: { COMPOSE_PROFILES: "d1-multi" } },
+      }
     );
   });
 });

--- a/tests/unit/integration-environment.test.js
+++ b/tests/unit/integration-environment.test.js
@@ -5,7 +5,7 @@ import { test } from "node:test";
 
 import {
   ROOT,
-  composeNoBuildFlag,
+  composeNoBuildArgs,
   resolveWdlCliBin,
 } from "../../scripts/integration-environment.js";
 import {
@@ -28,9 +28,9 @@ const composeHelper = await importRepositoryModule(
   })
 );
 
-test("compose no-build flag follows the integration environment", () => {
-  assert.equal(composeNoBuildFlag({ WDL_INTEGRATION_NO_BUILD: "1" }), " --no-build");
-  assert.equal(composeNoBuildFlag({}), "");
+test("compose no-build args follow the integration environment", () => {
+  assert.deepEqual(composeNoBuildArgs({ WDL_INTEGRATION_NO_BUILD: "1" }), ["--no-build"]);
+  assert.deepEqual(composeNoBuildArgs({}), []);
 });
 
 test("compose helpers consume the shared preflight no-build flag", async () => {

--- a/tests/unit/redis-session.test.js
+++ b/tests/unit/redis-session.test.js
@@ -215,46 +215,6 @@ test("RedisClient.hMGet returns decoded values and null misses", async () => {
   assert.ok(socket._reader.released, "per-call reader lock released after command");
 });
 
-test("RedisClient.hGetEx refreshes hash field TTLs while reading values", async () => {
-  const socket = makeFakeSocket([bytes("*3\r\n$1\r\na\r\n$-1\r\n$1\r\nc\r\n")]);
-  const { connect } = scriptedConnect(socket);
-  const client = new RedisClient("x", { connect });
-  const values = await client.hGetEx("h", 30, ["a", "b", "c"]);
-
-  assert.deepEqual(values, ["a", null, "c"]);
-  assert.equal(
-    decode(socket._writes[0]),
-    "*9\r\n$6\r\nHGETEX\r\n$1\r\nh\r\n$2\r\nEX\r\n$2\r\n30\r\n$6\r\nFIELDS\r\n$1\r\n3\r\n$1\r\na\r\n$1\r\nb\r\n$1\r\nc\r\n"
-  );
-  assert.ok(socket._reader.released, "per-call reader lock released after command");
-});
-
-test("RedisSession carries hash field TTL heartbeats on its held socket", async () => {
-  const socket = makeFakeSocket([
-    bytes("*2\r\n$1\r\n1\r\n$-1\r\n:9999\r\n:1\r\n"),
-  ]);
-  const { connect, state } = scriptedConnect(socket);
-  const client = new RedisClient("x", { connect });
-  const result = await client.session(async (/** @type {any} */ session) => {
-    const active = await session.hGetEx("logs:tail:active", 30, ["demo:a", "demo:b"]);
-    const count = await session.hLen("logs:tail:active");
-    const written = await session.hSetEx("logs:tail:active", 30, { "demo:b": "1" });
-    return { active, count, written };
-  });
-
-  assert.deepEqual(result, { active: ["1", null], count: 9999, written: 1 });
-  assert.equal(state.count, 1, "heartbeat commands must reuse one Redis socket");
-  assert.equal(
-    decode(socket._writes[0]),
-    "*8\r\n$6\r\nHGETEX\r\n$16\r\nlogs:tail:active\r\n$2\r\nEX\r\n$2\r\n30\r\n$6\r\nFIELDS\r\n$1\r\n2\r\n$6\r\ndemo:a\r\n$6\r\ndemo:b\r\n"
-  );
-  assert.equal(decode(socket._writes[1]), "*2\r\n$4\r\nHLEN\r\n$16\r\nlogs:tail:active\r\n");
-  assert.equal(
-    decode(socket._writes[2]),
-    "*8\r\n$6\r\nHSETEX\r\n$16\r\nlogs:tail:active\r\n$2\r\nEX\r\n$2\r\n30\r\n$6\r\nFIELDS\r\n$1\r\n1\r\n$6\r\ndemo:b\r\n$1\r\n1\r\n"
-  );
-});
-
 test("RedisSession.open fails explicitly after close", async () => {
   const socket = makeFakeSocket([]);
   const { connect } = scriptedConnect(socket);
@@ -638,30 +598,6 @@ test("RedisSession.getManyAndHGetMany reads locks and hash fields in one write",
       "*2\r\n$3\r\nGET\r\n$6\r\nlock:b\r\n" +
       "*3\r\n$4\r\nHGET\r\n$11\r\nroutes:demo\r\n$1\r\na\r\n" +
       "*3\r\n$4\r\nHGET\r\n$11\r\nbundle:demo\r\n$8\r\n__meta__\r\n"
-  );
-});
-
-test("RedisSession.hGetAllGetSMembers reads a delete snapshot in one write", async () => {
-  const socket = makeFakeSocket([
-    bytes("*2\r\n$5\r\nstate\r\n$5\r\nready\r\n$7\r\nd1_main\r\n*2\r\n$6\r\nworker\r\n$7\r\nversion\r\n"),
-  ]);
-  const { connect, state } = scriptedConnect(socket);
-  const client = new RedisClient("x", { connect });
-
-  const snapshot = await client.session((/** @type {any} */ session) =>
-    session.hGetAllGetSMembers("database", "alias", "referrers"));
-
-  assert.deepEqual(snapshot, {
-    hash: { state: "ready" },
-    value: "d1_main",
-    members: ["worker", "version"],
-  });
-  assert.equal(state.count, 1);
-  assert.equal(
-    decode(socket._writes[0]),
-    "*2\r\n$7\r\nHGETALL\r\n$8\r\ndatabase\r\n" +
-      "*2\r\n$3\r\nGET\r\n$5\r\nalias\r\n" +
-      "*2\r\n$8\r\nSMEMBERS\r\n$9\r\nreferrers\r\n"
   );
 });
 
@@ -1176,24 +1112,6 @@ test("RedisClient.existsAndXRange batches a stream resume snapshot", async () =>
     decode(socket._writes[0]),
     "*2\r\n$6\r\nEXISTS\r\n$18\r\nlogs:demo:worker:s\r\n" +
       "*6\r\n$6\r\nXRANGE\r\n$18\r\nlogs:demo:worker:s\r\n$1\r\n-\r\n$1\r\n+\r\n$5\r\nCOUNT\r\n$1\r\n1\r\n"
-  );
-});
-
-test("RedisClient batches independent HEXISTS checks on one socket", async () => {
-  const socket = makeFakeSocket([bytes(":1\r\n:0\r\n")]);
-  const { connect, state } = scriptedConnect(socket);
-  const client = new RedisClient("x", { connect });
-
-  assert.deepEqual(
-    await client.hExistsMany(["worker:demo:api:v1", "worker:demo:api:v2"], "__meta__"),
-    [true, false]
-  );
-
-  assert.equal(state.count, 1);
-  assert.equal(
-    decode(socket._writes[0]),
-    "*3\r\n$7\r\nHEXISTS\r\n$18\r\nworker:demo:api:v1\r\n$8\r\n__meta__\r\n" +
-      "*3\r\n$7\r\nHEXISTS\r\n$18\r\nworker:demo:api:v2\r\n$8\r\n__meta__\r\n"
   );
 });
 

--- a/tests/unit/style-contracts.test.js
+++ b/tests/unit/style-contracts.test.js
@@ -732,15 +732,15 @@ test("auth entrypoint keeps runtime IO mechanics in auth/runtime.js", () => {
   assert.deepEqual(offenders, []);
 });
 
-test("gateway entrypoint keeps persistent routing state in gateway/runtime.js", () => {
+test("gateway entrypoint keeps persistent state in Gateway owner modules", () => {
   const source = withoutLineComments(readRepoFile("gateway/index.js"));
   const offenders = [];
   // Request dispatch can consume runtime-owned routing state, but Redis clients,
-  // subscribers, mutable route caches, and cross-request memoization stay out of
-  // the entrypoint.
+  // subscribers, mutable route/lifecycle state, and cross-request memoization
+  // stay out of the entrypoint.
   if (/from\s+"shared-redis"/.test(source)) offenders.push("redis import");
   if (
-    /\b(?:RedisSubscriber|RedisClient|routeCache|patternCache|knownNs|knownPatternHosts|routeReads|patternReads)\b/.test(source) ||
+    /\b(?:RedisSubscriber|RedisClient|routeCache|patternCache|knownNs|knownPatternHosts|routeReads|patternReads|createGatewayWebSocketLifecycleManager)\b/.test(source) ||
     /\bnew\s+WeakMap\s*\(/.test(source)
   ) {
     offenders.push("runtime state");


### PR DESCRIPTION
## Summary

- Delete JavaScript code with no production callers: unused Redis command APIs and their fakes, the empty Control body mode, the D1 query function overload, and the `RegExp.escape` wrapper.
- Remove validation that a stronger gate already guarantees: the Gateway pattern namespace check that `sortPatterns` makes unreachable, the `sortPatterns` predicate guard that `typecheck:strict` rejects at build time, and per-request revalidation of the in-repo Auth issue templates, now indexed once at module load behind a static contract test.
- Inline single-caller Rust abstractions: workflow due promotion into its ready-tick owner, workflow definition verification into its DB0 check, and the generic remote tick into a workflow-specific boundary. Validate KV HMGET plans once at their construction boundary and compile the BTreeMap metric-key formatter only for its parity tests.
- Replace the test-only shell tokenizer, environment assignment parser, fallback syntax, and quote round-trip with explicit argv arrays across the integration helpers.
- Extract Gateway WebSocket lifecycle admission, registry/reconciliation, and atomic route/rollout reads into `gateway/websocket-lifecycle.js`, and point the entrypoint style contract at the manager factory that would carry that state.

## Behavior

No observable contract changes. Redis reply validation, empty-body rejection, reserved-namespace 404s, local envelope error wording, S3 checkpoint bounds, shard discovery, bounded overfetch, malformed-token cleanup, the fenced Lua move, and the disabled-host tick no-op are all retained. The bounded DEK cache is kept deliberately, with its rationale recorded for a future remote KMS provider.

## Validation

- `npm run lint`, `npm run typecheck`, `npm run typecheck:strict`, `npm run lint:unused`
- `npm run compile:workerd`
- `npm run test:unit` (2,285 tests)
- `cargo fmt --all --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace` (428 tests)
- `npm run test:integration` (55 integration files, 0 failures)

The consolidated branch produces a byte-identical tree to the unsquashed history it replaces (`c5503ad`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
